### PR TITLE
Add GiHub's action PoC

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,12 @@
+on: [push]
+
+jobs:
+  github_automation_job:
+    runs-on: ubuntu-latest
+    name: Runs GitHub Automation
+    steps:
+      - name: Runs GitHub Automation script
+        id: gh_auto
+        uses: scylladb/github-automation@v1
+        with:
+          pat-var: ${{ secrets.PAT }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python
+
+COPY entrypoint.sh /entrypoint.sh
+COPY requirements.txt /requirements.txt
+COPY gh_project_automation.py /gh_project_automation.py
+RUN pip install -r /requirements.txt
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,12 @@
+name: 'Run GitHub Automation'
+description: 'Performs some GraphQL queries & mutations in order to automatically update Issues & PRs'
+inputs:
+  pat-var:
+    description: 'Personal Access Token (PAT) to use when running Github Automation'
+    required: true
+    default: 'invalid'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  env:
+    PAT: ${{ inputs.pat-var }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -l
+
+python /gh_project_automation.py --project-name Eliran --team Eliran-team -l DEBUG $PAT
+

--- a/gh_project_automation.py
+++ b/gh_project_automation.py
@@ -42,6 +42,7 @@ class GithubAPI:
         if 'errors' in response.json():
             logging.error(response.json())
             sys.exit("Error when processing request, most probably due to malformed GraphQL, exiting...")
+        logging.debug(response.json())
         return response
 
     def get_project_views_filters(self, organization, project_number, page_size=100):


### PR DESCRIPTION
This change adds an example github action that runs the gh_project_automation.py script on every push to this github repository. This is just an example that still needs to be worked on and only intends to present how to integrate our automation script with github's actions. You can check out how this action looks like by going to this repository's Actions tab. 

Currently, the GH action script has "Eliran" project/team hardcoded in `entrypoint.sh`, and we have to think how we'd want to generalize it. I can see 2 options. Option 1 is to hardcode projects and teams in the action/entrypoint's code. This makes it explicit for which projects/teams the action will run, but also will require to modify action's code whenever we'd like to add another team/project. Option 2 is to pass projects/teams as github repository's variables, which wouldn't require action's code modifications, but would require defining variables for each repository where the action should run.

BTW. to add a Repository Secret one has to go to github repository's Settings -> Secrets and variables -> Actions tab -> New repository secret (not environment secrets!). If modifying github action's code, one has to also remember to update the git tag: bump the version in the script inside the .github dir, create a tag and push it along with the commit, e.g. by running 'git push --follow-tags' or 'git push origin <tag>'.