### PR TITLE
Added a functionality to query for issues' events since the beginning of the last week

### DIFF
--- a/.github/workflows/auto-assign-per-team.yml
+++ b/.github/workflows/auto-assign-per-team.yml
@@ -40,4 +40,4 @@ jobs:
       - name: execute gh_project_automation.py
         env:
           GITHUB_SECRET: ${{ secrets.ISSUE_ASSIGNMENT_TO_PROJECT_TOKEN }}
-        run: python gh_project_automation.py $GITHUB_SECRET --team ${{ matrix.team }} --project-name ${{ matrix.project-name }} --update-project
+        run: python gh_project_automation.py $GITHUB_SECRET --team ${{ matrix.team }} --project-name ${{ matrix.project-name }} --update-project --weekly-reports


### PR DESCRIPTION
There're many events GraphQL allows to query from, but this is still a
limited subset of all the possibilities. I chose some events, but after running
queries I realized they're not all that necessary, hence I removed:
- MentionedEvent (we don't have to do anything in case of such an event, it's just a noise)
- CrossReferencedEvent - as above
- ReferencedEvent - as above
- UnassignedEvent (we're no longer interested in this issue if it has been unassigned from someone from our team)
Another thing is that I left epxlicitly listed events' types in GraphQL
query (the other option was to collapse them into a list and generate,
using e.g. python's list comprehension), as I think we may want to
extract more info from them later in the future, and all of them offer
different fields, so this cannot be generalized.
Events data have been transformed into a string, which I found more user
friendly - it gives basic data plus a URL to the issue, and looks
somewhat like this:
```
2023-04-10 11:52:05,022 [INFO] Found event: Assignees: ['Calle Wilund', 'Eliran Sinvani'], issue URL: https://github.com/scylladb/scylla-enterprise/issues/2792, event: AssignedEvent made by: DoronArazii
```
The data used in the query for issues' events ("since:") is hardcoded,
and we always asks for events at most 7 days old starting from the script
run, but this can be made e.g. a command line parameter.

EDIT:
Extended GraphQL's query with PRs' events. Unfortunately, the only way
to do it was to list all PRs' events separately from Issues's events in
the query, because Issues cannot have some of the PRs events and GitHub
rejected queries where it was the cause with an error, e.g.: "Fragment
on ReadyForReviewEvent can't be spread inside IssueTimelineItems".
An example PR's events are logged as:
```
2023-04-23 11:51:29,440 [INFO] Found event: Assignees: [['piodul']], URL: https://github.com/scylladb/scylla-rust-driver/pull/665, event: ReviewRequestedEvent made by: wprzytula
```
Also events are sorted by assignee/author and duplicates are removed.
(Duplicates were created when 2 pepople were assigned to 1 issue, and
we'd query for the first person's issues and then second person's
issues, which would return duplicates).
Weekly reports (events from the lats 7 days) can be enabled by passing
`--weekly-reports` command line parameter.

EDIT2:
Finally I found a comprehensive documentation listing more events
available for both PullRequest -
https://docs.github.com/en/webhooks-and-events/events/github-event-types
I think that the current list of events included in this PR should make this feature
really useful.

EDIT3:
Collapsed events coming from the same issue/pr into a single entry.

EDIT4:
After rebasing with `main`, enable generating reports in Actions. We
won't have to run the script manually every time we want a report, it's
enough to visit Actions tab and copy-paste it.