### PR TITLE
Do not crash on an empty view

### DIFF
--- a/gh_project_automation.py
+++ b/gh_project_automation.py
@@ -468,6 +468,8 @@ def run_update():
         pos = 0
         broken_filter = {}
         prev_filter = None
+        if f is None:
+            continue
         while m := filter_cats.search(f):
             if prev_filter is not None:
                 broken_filter[prev_filter] = f[:m.span(0)[0]]


### PR DESCRIPTION
When someone creates a new view on the project board by clicking on "+New View" and does not do anything more, an empty view will be created and saved, which will make our bot fail on the following error when querying for the project's views:
```
  File ".../gitHub-automation/gh_project_automation.py", line 478, in run
    while m := filter_cats.search(f):
               ^^^^^^^^^^^^^^^^^^^^^
TypeError: expected string or bytes-like object, got 'NoneType'
```
We cannot pass `None` to the regexp search, hence I just added a check to skip such views - they don't have any filters/labels either way.