### PR TITLE
Skip adding Issues with P*/customer/top10 labels

### DIFF
--- a/gh_project_automation.py
+++ b/gh_project_automation.py
@@ -484,6 +484,15 @@ def run_update():
         broken_labels = map(lambda x: x.replace('"', '').strip(), broken_labels)
         labels = labels.union(set(broken_labels))
 
+    def matches_blacklisted_labels(label):
+        blacklisted_labels_regexp = ["^P[0-9]$", "^customer*", "^top10$"]
+        for regexp in blacklisted_labels_regexp:
+            if re.search(regexp, label):
+                return True
+        return False
+
+    labels = [x for x in labels if not matches_blacklisted_labels(x)]
+
     logging.info(f"Found {len(labels)} labels in the project: {labels}")
     labels_query = "label:" + ",".join(['"' + x + '"' for x in labels])
     logging.debug(labels_query)


### PR DESCRIPTION
It may happen that someone uses github project's view to create a filter by e.g. his nickname and a `P1` label. In that case our github automation bot would fetch `P1` label from this view
and add all issues with `P1` label to our project. Most of them wouldn't probably belong and should not be added to the project. Per @eliransin, in order to protect ourselves from adding ALL issues with `P1`, `P2`, `P3` or `customer`, `customer/*` or `top10` labels to the projects, we introduce a label's blacklist to prevent that from happening.
If anyone creates a filter containing "forbidden" labels, these labels simply won't be considered by our github automation bot when analyzing which issues should be added to the project. It doesn't mean Issues with e.g. `P1` label won't be added to the projects at all - if an issue with `P1` label has any other "matching" label, e.g. "audit" label, such an issue will still be added to the project, but just by "audit" label, and not "P1" label.