### PR TITLE
Ignore labels case when filering out P*/Top10 labels

### DIFF
--- a/gh_project_automation.py
+++ b/gh_project_automation.py
@@ -494,7 +494,7 @@ def run():
     def matches_blacklisted_labels(label):
         blacklisted_labels_regexp = ["^P[0-9]$", "^customer*", "^top10$"]
         for regexp in blacklisted_labels_regexp:
-            if re.search(regexp, label):
+            if re.search(regexp, label, re.IGNORECASE):
                 return True
         return False
 


### PR DESCRIPTION
Adding @eliransin and @yaronkaikov just for the visibility's sake. We could have some unwanted issues added to projects if a project happened to have a view/tab with a filter set to P*/Top10 label, because we were matching a regexp according to filter's case. Now we ignore the case, but issues added to the project accidentally should be removed from it.
BTW. If you want to quickly check (and remove) such issues, go to scylla-enterprise git repo, filter by project + label and you have a list of Issues to be removed from project. From this point on, I'm afraid, the removal process is a manual job.