### PR TITLE
Rename project and team (Eliran -> Backend)

### DIFF
--- a/.github/workflows/auto-assign-per-team.yml
+++ b/.github/workflows/auto-assign-per-team.yml
@@ -15,7 +15,7 @@ jobs:
         team:
          - releng
          - storage
-         - Eliran-team
+         - core-backend
          - CoreFront
          - Drivers-Team
         include:
@@ -23,8 +23,8 @@ jobs:
             project-name: Release
           - team: storage
             project-name: Storage
-          - team: Eliran-team
-            project-name: Eliran
+          - team: core-backend
+            project-name: 'Core - Backend'
           - team: CoreFront
             project-name: CoreFront
           - team: drivers-team


### PR DESCRIPTION
Finally we have better definitions for teams than just by TL name. This changes the automation for my new teams (and project) name.