### PR TITLE
github automation: fix search by label

### DIFF
--- a/gh_project_automation.py
+++ b/gh_project_automation.py
@@ -510,7 +510,7 @@ def run():
     issues_ids = []
     for label in labels:
         found_ids = gh_api.get_issues_ids(
-            f"is:open org:scylladb is:issue -project:scylladb/{project_number} label:{label}")
+            f"is:open org:scylladb is:issue -project:scylladb/{project_number} label:\\\"{label}\\\"")
         if len(found_ids) > 0:
             logging.info(f"'{label}' label's not added issues count: " + str(len(found_ids)))
             issues_ids += found_ids


### PR DESCRIPTION
The current filter produced by the search by label is wrong, it has a search filter, that ends with 'label: XXX', however if the label contains spaces for example: 'XXX YYY' what the search will look like is 'label:XXX YYY' which means search for issues with label 'XXX' and that contains 'YYY' the solution is to change the filter to put double quotes around the label name ('label:"XXX YYY"').
Here we implement this solution.
I found out about this when I noticed that the automation is "blind" to some of my labels.

Tested locally on my own project.