### PR TITLE
Store project's labels in git repo instead of scraping them from project's  views

### DIFF
--- a/.github/workflows/auto-assign-per-team.yml
+++ b/.github/workflows/auto-assign-per-team.yml
@@ -16,19 +16,24 @@ jobs:
          - releng
          - storage
          - core-backend
-         - CoreFront
+         - core-frontend
          - Drivers-Team
         include:
           - team: releng
             project-name: Release
+            labels: "[]"
           - team: storage
             project-name: Storage
+            labels: "[]"
           - team: core-backend
             project-name: Core_-_Backend
-          - team: CoreFront
+            labels: "['counters', 'materialized-views', 'UDF', 'workload-prioritization', 'LDAP', 'wasm', 'security/EncryptionAtRest', 'Security', 'AlternatorStreams', 'security', 'CQL', 'workload-prio', 'materialized views', 'AlternatorQueryLanguage', 'Alternator', 'commit-log-hard-limit', 'commit-log', 'sec-index']"
+          - team: core-frontend
             project-name: Core_-_Frontend
+            labels: "['guardrails', 'Security', 'security/Audit']"
           - team: drivers-team
             project-name: Drivers-Team
+            labels: "[]"
     steps:
       - name: checkout repo content
         uses: actions/checkout@v3 # checkout the repository content
@@ -46,4 +51,4 @@ jobs:
       - name: execute gh_project_automation.py
         env:
           GITHUB_SECRET: ${{ secrets.ISSUE_ASSIGNMENT_TO_PROJECT_TOKEN }}
-        run: python gh_project_automation.py $GITHUB_SECRET --team ${{ matrix.team }} --project-name ${{ matrix.project-name }} --update-project --weekly-reports
+        run: python gh_project_automation.py $GITHUB_SECRET --team ${{ matrix.team }} --project-name ${{ matrix.project-name }} --labels "${{ matrix.labels }}" --update-project --weekly-reports


### PR DESCRIPTION
It happened more than once that a project view has been created and this
view accidentally listed a label that didn't belong to the project,
which resulted in issues having this label being added to the project.
The only way to revert this situation was to destroy the view and
manually go over each of accidentally added issues and remove them from
the project. Other than that, this functionality of scraping project's
labels from views disallows from creating a custom view, i.e. a view
that an author doesn't wish to be scraped by the bot - the only thing
allowed, with regards to a custom view, is to create it, but not save
it, as the act of saving is visible by the bot.
For these reasons I see this automatic labels scraping functionality
unsafe, though very convenient, and for it to not happen again I propose
to store project's labels in this git repository. Editing project's
labels will still be trivial, as github's online API allows one to do it
in the web browser, i.e. one can edit github's workflow
`gh_project_automation.py` file from the web browser.
As of now only 2 projects use labels, and I took them from the bot's
debug messages - the bot always printed the labels it's going to search
for. OTOH these labels need to be reviewed, because there's mismatch
between core's -frontend and -backend teams.