### PR TITLE
Clear some project's labels

### DIFF
--- a/.github/workflows/auto-assign-per-team.yml
+++ b/.github/workflows/auto-assign-per-team.yml
@@ -27,7 +27,7 @@ jobs:
             labels: "[]"
           - team: core-backend
             project-name: Core_-_Backend
-            labels: "['counters', 'materialized-views', 'UDF', 'workload-prioritization', 'LDAP', 'wasm', 'security/EncryptionAtRest', 'Security', 'AlternatorStreams', 'security', 'CQL', 'workload-prio', 'materialized views', 'AlternatorQueryLanguage', 'Alternator', 'commit-log-hard-limit', 'commit-log', 'sec-index']"
+            labels: "['counters', 'materialized-views', 'UDF', 'workload-prioritization', 'LDAP', 'wasm', 'security/EncryptionAtRest', 'AlternatorStreams', 'workload-prio', 'materialized views', 'AlternatorQueryLanguage', 'Alternator', 'commit-log-hard-limit', 'commit-log', 'sec-index']"
           - team: core-frontend
             project-name: Core_-_Frontend
             labels: "['guardrails', 'Security', 'security/Audit']"


### PR DESCRIPTION
These labels have been either shared between 2 teams or no longer apply to a team.
ATM I am not assigning `CQL` label to `core-frontend` team, I'd rather include issues to the team's project manually.