### PR TITLE
github actions: change actions/checkout to v4

### DIFF
--- a/.github/workflows/auto-assign-per-team.yml
+++ b/.github/workflows/auto-assign-per-team.yml
@@ -36,7 +36,7 @@ jobs:
             labels: "[]"
     steps:
       - name: checkout repo content
-        uses: actions/checkout@v3 # checkout the repository content
+        uses: actions/checkout@v4 # checkout the repository content
 
       - name: setup python
         uses: actions/setup-python@v4


### PR DESCRIPTION
following the warning message we got:
```
Update project Storage for storage members
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-python@v4. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```