### PR TITLE
bump actions/setup-python to v5

### DIFF
--- a/.github/workflows/auto-assign-per-team.yml
+++ b/.github/workflows/auto-assign-per-team.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v4 # checkout the repository content
 
       - name: setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11' # install the python version needed
 


### PR DESCRIPTION
During the github action we get the following warning
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-python@v4. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```