### PR TITLE
github automation: adjust labels for core-frontend and core-backend teams

### DIFF
--- a/.github/workflows/auto-assign-per-team.yml
+++ b/.github/workflows/auto-assign-per-team.yml
@@ -27,10 +27,10 @@ jobs:
             labels: "[]"
           - team: core-backend
             project-name: Core_-_Backend
-            labels: "['area/counters', 'area/materialized views', 'area/udf', 'area/workload prioritization', 'area/ldap', 'area/wasm', 'area/encryption at rest', 'area/alternator-streams', 'area/workload prioritization', 'area/materialized views', 'area/alternator', 'area/commitlog hard limit', 'area/commitlog', 'area/sec index']"
+            labels: "['area/materialized views', 'area/udf', 'area/workload prioritization', 'area/ldap', 'area/wasm', 'area/encryption at rest', 'area/workload prioritization', 'area/materialized views', 'area/commitlog hard limit', 'area/commitlog', 'area/sec index']"
           - team: core-frontend
             project-name: Core_-_Frontend
-            labels: "['area/guardrails', 'area/security', 'security/audit']"
+            labels: "['area/guardrails', 'area/security', 'security/audit', 'area/alternator', 'area/alternator-streams']"
           - team: drivers-team
             project-name: Drivers-Team
             labels: "[]"


### PR DESCRIPTION
This PR does two things:

- A standard for label names was recently introduced and current labels on GitHub were updated accordingly, but not in this repo's `auto-assign-per-team.yml` file - they are now updated here as well.
- In order to reflect the current responsibilities of core-frontend and core-backend, removes counters from the responsibilities of core-backend and moves alternator-related labels from core-backend to core-frontend.