### PR TITLE
Disable issues auto-assignment for core-frontend & -backend

### DIFF
--- a/.github/workflows/auto-assign-per-team.yml
+++ b/.github/workflows/auto-assign-per-team.yml
@@ -27,10 +27,10 @@ jobs:
             labels: "[]"
           - team: core-backend
             project-name: Core_-_Backend
-            labels: "['area/materialized views', 'area/udf', 'area/workload prioritization', 'area/ldap', 'area/wasm', 'area/encryption at rest', 'area/workload prioritization', 'area/materialized views', 'area/commitlog hard limit', 'area/commitlog', 'area/sec index']"
+            labels: "[]"
           - team: core-frontend
             project-name: Core_-_Frontend
-            labels: "['area/guardrails', 'area/security', 'security/audit', 'area/alternator', 'area/alternator-streams']"
+            labels: "[]"
           - team: drivers-team
             project-name: Drivers-Team
             labels: "[]"


### PR DESCRIPTION
This was suggested by @kostja. The motivation is that either issues are assigned 2+ projects based on labels or that labels are (still) wrong hence wrong projects are assigned.
Note that no labels are defined for other teams, only these 2 teams used them.
This is just an idea, it has to be yet discussed and agreed on - no decision has been made yet whether we disable this functionality. 