### PR TITLE
Adding new automatic action sending weekly reports containing git metrics

### DIFF
--- a/.github/workflows/github-metrics-report.yml
+++ b/.github/workflows/github-metrics-report.yml
@@ -33,7 +33,7 @@ jobs:
       uses: github/issue-metrics@v3.4.0
       env:
         GH_TOKEN:  ${{ secrets.ISSUE_ASSIGNMENT_TO_PROJECT_TOKEN }}
-        SEARCH_QUERY: 'repo:dani-tweig/scylladb/scylla-enterprise is:issue closed:${{ env.last_week }}'
+        SEARCH_QUERY: 'repo:scylladb/scylla-enterprise is:issue closed:${{ env.last_week }}'
         HIDE_TIME_TO_ANSWER: true
         HIDE_TIME_TO_FIRST_RESPONSE: true
         ENABLE_MENTOR_COUNT: true
@@ -51,7 +51,7 @@ jobs:
       uses: github/issue-metrics@v3.4.0
       env:
         GH_TOKEN:  ${{ secrets.ISSUE_ASSIGNMENT_TO_PROJECT_TOKEN }}
-        SEARCH_QUERY: 'repo:dani-tweig/scylladb/scylla-enterprise is:pr closed:${{ env.last_week }}'
+        SEARCH_QUERY: 'repo:scylladb/scylla-enterprise is:pr closed:${{ env.last_week }}'
         HIDE_TIME_TO_ANSWER: true
         HIDE_TIME_TO_FIRST_RESPONSE: true
         ENABLE_MENTOR_COUNT: true
@@ -68,7 +68,7 @@ jobs:
       uses: github/issue-metrics@v3.4.0
       env:
         GH_TOKEN:  ${{ secrets.ISSUE_ASSIGNMENT_TO_PROJECT_TOKEN }}
-        SEARCH_QUERY: 'repo:dani-tweig/scylladb/scylla-enterprise closed:${{ env.last_week }}'
+        SEARCH_QUERY: 'repo:scylladb/scylla-enterprise closed:${{ env.last_week }}'
         HIDE_TIME_TO_ANSWER: true
         HIDE_TIME_TO_FIRST_RESPONSE: true
         ENABLE_MENTOR_COUNT: true


### PR DESCRIPTION
Creating an automation based on github action which will send github metrics every Sunday to the github-metrics-report@scylladb.com group

Fixes https://github.com/scylladb/github-automation/issues/32 