### PR TITLE
Update the main github actions changing Jira status

### DIFF
--- a/.github/workflows/extract_jira_keys.yml
+++ b/.github/workflows/extract_jira_keys.yml
@@ -1,0 +1,55 @@
+name: Extract Jira Keys
+
+on:
+  workflow_call:
+    inputs:
+      pr_title:
+        required: true
+        type: string
+      pr_body:
+        required: true
+        type: string
+    outputs:
+      jira-keys-csv:
+        description: "Comma-separated Jira keys"
+        value: ${{ jobs.extract.outputs.jira-keys-csv }}
+      jira-keys-json:
+        description: "JSON array of Jira keys"
+        value: ${{ jobs.extract.outputs.jira-keys-json }}
+
+jobs:
+  extract:
+    runs-on: ubuntu-latest
+    outputs:
+      jira-keys-csv: ${{ steps.extract.outputs.jira-keys-csv }}
+      jira-keys-json: ${{ steps.extract.outputs.jira-keys-json }}
+    steps:
+      - id: extract
+        shell: bash
+        run: |
+          set -euo pipefail
+          title="$(printf '%s' "${{ inputs.pr_title }}" | tr '`' ' ')"
+          body="$(printf '%s' "${{ inputs.pr_body }}"  | tr '`' ' ')"
+
+          > tickets.txt
+          printf '%s\n' "$title" | grep -oE '[A-Z]+-[0-9]+' >> tickets.txt || true
+          printf '%s\n' "$body"  | grep -iE 'Fixes[[:space:]]*[: ][[:space:]]*((https?://[^[:space:]]*/browse/)?[A-Z]+-[0-9]+)' \
+                                | grep -oE '[A-Z]+-[0-9]+' >> tickets.txt || true
+
+          sort -u tickets.txt > unique_tickets.txt
+
+          if [[ ! -s unique_tickets.txt ]]; then
+            echo "jira-keys-csv=" >> "$GITHUB_OUTPUT"
+            echo "jira-keys-json=[]" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Found Jira tickets:"
+          cat unique_tickets.txt
+
+          csv=$(paste -sd, unique_tickets.txt)
+          json=$(awk '{printf "\"%s\",",$1}' unique_tickets.txt | sed 's/,$//')
+          json="[${json}]"
+
+          echo "jira-keys-csv=$csv"   >> "$GITHUB_OUTPUT"
+          echo "jira-keys-json=$json" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/jira_transition.yml
+++ b/.github/workflows/jira_transition.yml
@@ -1,0 +1,39 @@
+name: Jira Transition
+
+on:
+  workflow_call:
+    inputs:
+      jira_key:
+        required: true
+        type: string
+      transition_name:
+        required: true
+        type: string
+      transition_id:
+        required: true
+        type: string
+    secrets:
+      jira_auth:
+        required: true
+
+jobs:
+  transition:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Transition Jira Ticket
+        env:
+          JIRA_AUTH: ${{ secrets.jira_auth }}
+        run: |
+          set -euo pipefail
+          if [ -z "${JIRA_AUTH:-}" ]; then
+            echo "ERROR: JIRA_AUTH secret is not set."
+            exit 1
+          fi
+
+          echo "Transitioning Jira ticket ${{ inputs.jira_key }} to transition ${{ inputs.transition_name }}"
+          curl -v --fail -X POST \
+            --url "https://scylladb.atlassian.net/rest/api/3/issue/${{ inputs.jira_key }}/transitions" \
+            --user "$JIRA_AUTH" \
+            --header "Accept: application/json" \
+            --header "Content-Type: application/json" \
+            -d "{\"transition\": {\"id\": \"${{ inputs.transition_id }}\"}}"

--- a/.github/workflows/main_update_jira_status_to_in_progress.yml
+++ b/.github/workflows/main_update_jira_status_to_in_progress.yml
@@ -3,61 +3,26 @@ name: Update Jira Status - In Progress
 on:
   workflow_call:
     secrets:
-      jira_auth:
+      caller_jira_auth:
         required: true
 
 jobs:
-  action-jira-status-update:
-    runs-on: ubuntu-latest
+  extract:
+    uses: scylladb/github-automation/.github/workflows/extract_jira_keys.yml@main
+    with:
+      pr_title: ${{ github.event.pull_request.title }}
+      pr_body:  ${{ github.event.pull_request.body }}
 
-    steps:
-      - name: Extract Jira Ticket IDs
-        id: get-jira
-        shell: bash
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_BODY:  ${{ github.event.pull_request.body }}
-        run: |
-          set -euo pipefail
-
-          # Replace backticks with spaces (no evaluation)
-          title="$(printf '%s' "$PR_TITLE" | tr '`' ' ')"
-          body="$(printf '%s' "$PR_BODY"  | tr '`' ' ')"
-
-          > tickets.txt
-          printf '%s\n' "$title" | grep -oE '[A-Z]+-[0-9]+' >> tickets.txt || true
-          printf '%s\n' "$body"  | grep -iE '^Fixes[[:space:]]*[: ][[:space:]]*[A-Z]+-[0-9]+' \
-                                | grep -oE '[A-Z]+-[0-9]+' >> tickets.txt || true
-
-          sort -u tickets.txt > unique_tickets.txt
-          if [[ ! -s unique_tickets.txt ]]; then
-            echo "ticket-ids=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          tickets_csv=$(paste -sd, unique_tickets.txt)
-          echo "ticket-ids=$tickets_csv" >> "$GITHUB_OUTPUT"
-
-      - name: Transition Jira Tickets to 'In Progress'
-        if: steps.get-jira.outputs.ticket-ids != ''
-        env:
-          JIRA_AUTH: ${{ secrets.jira_auth }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          if [ -z "${JIRA_AUTH:-}" ]; then
-            echo "ERROR: JIRA_AUTH secret is empty. Secret was not passed correctly from the calling workflow."
-            exit 1
-          fi
-
-          IFS=',' read -ra tickets <<< "${{ steps.get-jira.outputs.ticket-ids }}"
-          for ticket_id in "${tickets[@]}"; do
-            echo "Transitioning Jira ticket to 'In Progress': $ticket_id"
-            curl -v --fail -X POST \
-              --url "https://scylladb.atlassian.net/rest/api/3/issue/${ticket_id}/transitions" \
-              --user "$JIRA_AUTH" \
-              --header "Accept: application/json" \
-              --header "Content-Type: application/json" \
-              -d '{"transition": {"id": "111"}}'
-          done
+  transition:
+    needs: extract
+    if: ${{ needs.extract.outputs.jira-keys-json != '[]' }}
+    uses: scylladb/github-automation/.github/workflows/jira_transition.yml@main
+    with:
+      jira_key: ${{ matrix.jira_key }}
+      transition_name: "In Progress"
+      transition_id: "111"
+    secrets:
+      jira_auth: ${{ secrets.caller_jira_auth }}
+    strategy:
+      matrix:
+        jira_key: ${{ fromJSON(needs.extract.outputs.jira-keys-json) }}

--- a/.github/workflows/main_update_jira_status_to_in_review.yml
+++ b/.github/workflows/main_update_jira_status_to_in_review.yml
@@ -3,60 +3,26 @@ name: Update Jira Status - In Review
 on:
   workflow_call:
     secrets:
-      jira_auth:
+      caller_jira_auth:
         required: true
 
 jobs:
-  action-jira-status-update-in-review:
-    runs-on: ubuntu-latest
+  extract:
+    uses: scylladb/github-automation/.github/workflows/extract_jira_keys.yml@main
+    with:
+      pr_title: ${{ github.event.pull_request.title }}
+      pr_body:  ${{ github.event.pull_request.body }}
 
-    steps:
-      - name: Extract Jira Ticket IDs
-        id: get-jira
-        shell: bash
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_BODY:  ${{ github.event.pull_request.body }}
-        run: |
-          set -euo pipefail
-
-          # Single-line: replace backticks with spaces, no evaluation
-          title="$(printf '%s' "$PR_TITLE" | tr '`' ' ')"
-          body="$(printf '%s' "$PR_BODY"  | tr '`' ' ')"
-
-          > tickets.txt
-          printf '%s\n' "$title" | grep -oE '[A-Z]+-[0-9]+' >> tickets.txt || true
-          printf '%s\n' "$body"  | grep -iE '^Fixes[[:space:]]*[: ][[:space:]]*[A-Z]+-[0-9]+' \
-                                | grep -oE '[A-Z]+-[0-9]+' >> tickets.txt || true
-
-          sort -u tickets.txt > unique_tickets.txt
-          if [[ ! -s unique_tickets.txt ]]; then
-            echo "ticket-ids=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          tickets_csv=$(paste -sd, unique_tickets.txt)
-          echo "ticket-ids=$tickets_csv" >> "$GITHUB_OUTPUT"
-
-      - name: Transition Jira Tickets to 'In Review'
-        if: steps.get-jira.outputs.ticket-ids != ''
-        env:
-          JIRA_AUTH: ${{ secrets.jira_auth }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          IFS=',' read -ra tickets <<< "${{ steps.get-jira.outputs.ticket-ids }}"
-          if [ -z "${JIRA_AUTH:-}" ]; then
-            echo "ERROR: JIRA_AUTH secret is empty. Secret was not passed correctly from the calling workflow."
-            exit 1
-          fi
-
-          for ticket_id in "${tickets[@]}"; do
-            echo "Transitioning Jira ticket to 'In Review': $ticket_id"
-            curl -v --fail -X POST \
-              --url "https://scylladb.atlassian.net/rest/api/3/issue/${ticket_id}/transitions" \
-              --user "$JIRA_AUTH" \
-              --header "Accept: application/json" \
-              --header "Content-Type: application/json" \
-              -d '{"transition": {"id": "121"}}'
-          done
+  transition:
+    needs: extract
+    if: ${{ needs.extract.outputs.jira-keys-json != '[]' }}
+    uses: scylladb/github-automation/.github/workflows/jira_transition.yml@main
+    with:
+      jira_key: ${{ matrix.jira_key }}
+      transition_name: "In Review"
+      transition_id: "121"
+    secrets:
+      jira_auth: ${{ secrets.caller_jira_auth }}
+    strategy:
+      matrix:
+        jira_key: ${{ fromJSON(needs.extract.outputs.jira-keys-json) }}

--- a/.github/workflows/main_update_jira_status_to_ready_for_merge.yml
+++ b/.github/workflows/main_update_jira_status_to_ready_for_merge.yml
@@ -3,65 +3,27 @@ name: Update Status - Ready For Merge
 on:
   workflow_call:
     secrets:
-      jira_auth:
+      caller_jira_auth:
         required: true
 
 jobs:
-  action-jira-status-update-ready-for-merge:
-    # gate the job by the label from the PR event
+  extract:
     if: ${{ github.event.label.name == 'status/merge_candidate' }}
-    runs-on: ubuntu-latest
+    uses: scylladb/github-automation/.github/workflows/extract_jira_keys.yml@main
+    with:
+      pr_title: ${{ github.event.pull_request.title }}
+      pr_body:  ${{ github.event.pull_request.body }}
 
-    steps:
-      - name: Extract Jira Ticket IDs
-        id: get-jira
-        shell: bash
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_BODY:  ${{ github.event.pull_request.body }}
-        run: |
-          set -euo pipefail
-          echo "Label 'status/merge_candidate' detected. Looking for Jira ticket IDs..."
-
-          # Replace backticks with spaces (no evaluation)
-          title="$(printf '%s' "${PR_TITLE:-}" | tr '`' ' ')"
-          body="$(printf '%s' "${PR_BODY:-}"  | tr '`' ' ')"
-
-          > tickets.txt
-          printf '%s\n' "$title" | grep -oE '[A-Z]+-[0-9]+' >> tickets.txt || true
-          printf '%s\n' "$body"  | grep -iE 'Fixes[[:space:]]*[: ][[:space:]]*((https?://[^[:space:]]*/browse/)?[A-Z]+-[0-9]+)' \
-                                | grep -oE '[A-Z]+-[0-9]+' >> tickets.txt || true
-
-          sort -u tickets.txt > unique_tickets.txt
-          if [[ ! -s unique_tickets.txt ]]; then
-            echo "No Jira tickets found in PR title or body. Skipping Jira update."
-            echo "ticket-ids=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          tickets_csv=$(paste -sd, unique_tickets.txt)
-          echo "ticket-ids=$tickets_csv" >> "$GITHUB_OUTPUT"
-
-
-      - name: Transition Jira Tickets to 'Ready for Merge'
-        if: steps.get-jira.outputs.ticket-ids != ''
-        env:
-          JIRA_AUTH: ${{ secrets.jira_auth }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [ -z "${JIRA_AUTH:-}" ]; then
-            echo "ERROR: JIRA_AUTH secret is empty. Secret was not passed correctly from the calling workflow."
-            exit 1
-          fi
-
-          IFS=',' read -ra tickets <<< "${{ steps.get-jira.outputs.ticket-ids }}"
-          for ticket_id in "${tickets[@]}"; do
-            echo "Transitioning Jira ticket to 'Ready for Merge': $ticket_id"
-            curl -v --fail -X POST \
-              --url "https://scylladb.atlassian.net/rest/api/3/issue/${ticket_id}/transitions" \
-              --user "$JIRA_AUTH" \
-              --header "Accept: application/json" \
-              --header "Content-Type: application/json" \
-              -d '{"transition": {"id": "131"}}'
-          done
+  transition:
+    needs: extract
+    if: ${{ needs.extract.outputs.jira-keys-json != '[]' }}
+    uses: scylladb/github-automation/.github/workflows/jira_transition.yml@main
+    with:
+      jira_key: ${{ matrix.jira_key }}
+      transition_name: "Ready For Merge"
+      transition_id: "131"
+    secrets:
+      jira_auth: ${{ secrets.caller_jira_auth }}
+    strategy:
+      matrix:
+        jira_key: ${{ fromJSON(needs.extract.outputs.jira-keys-json) }}


### PR DESCRIPTION
Jira status update, based on the PR progress, is managed in the github-automation repo.
The code was enhanced to support fork PRs.
Some of the code was split into modules:
* extract Jira keys from the title and body of a PR
* Update the status of a Jira issue

These modules are used for three actions:

1. Update Jira status to In Progress, triggered by the creation of a PR linked to the Jira issue
2. Update Jira status to In Review, triggered by a PR review request
3. Update Jira status to Ready For Merge, triggered by adding the 'status/merge_candidate' label in the PR
