### PR TITLE
Add aws instance monitor and daily report

### DIFF
--- a/.github/workflows/daily-aws-instance-monitor.yml
+++ b/.github/workflows/daily-aws-instance-monitor.yml
@@ -1,0 +1,36 @@
+name: Daily AWS Instance Monitor
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Runs daily at midnight UTC
+  workflow_dispatch:  # Allows manual triggering
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install boto3 tabulate
+
+    - name: Run AWS Instance Monitor
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        SMTP_SERVER: "smtp.gmail.com"
+        SMTP_PORT: "587"
+        SMTP_USER: ${{ secrets.SMTP_USER }}
+        SMTP_PASS: ${{ secrets.SMTP_PASS }}
+        EMAIL_FROM: "it.admin@scylladb.com"
+        EMAIL_TO: "releng-team@scylladb.com"
+      run: python aws_instance_monitor.py

--- a/aws_instance_monitor/README.md
+++ b/aws_instance_monitor/README.md
@@ -1,0 +1,84 @@
+# AWS Instance Monitor
+
+This Python script retrieves all running EC2 instances in your AWS account and displays them in a table format, including all associated tags.
+
+## Prerequisites
+
+- Python 3.x installed
+- AWS credentials configured (e.g., via AWS CLI, environment variables, or IAM roles)
+- Required Python packages: `boto3`, `tabulate`
+- (Optional) SMTP settings for email notifications
+
+## Installation
+
+1. Clone or download this repository.
+2. Install dependencies:
+   ```
+   pip install boto3 tabulate
+   ```
+
+## Usage
+
+Run the script using Python:
+
+```
+python aws_instance_monitor.py
+```
+
+Set the following environment variables for email notifications:
+- `SMTP_SERVER` (e.g., smtp.gmail.com)
+- `SMTP_PORT` (e.g., 587)
+- `SMTP_USER`
+- `SMTP_PASS`
+- `EMAIL_FROM`
+- `EMAIL_TO` (comma-separated list of email addresses for multiple recipients)
+
+The script will display the table of running instances and automatically terminate any instances that have exceeded their 'keep' time (in hours) or 8 hours if no 'keep' tag is set.
+
+**Warning:** This script will terminate EC2 instances. Ensure you have the necessary permissions and that termination is intended.
+
+The script will output a table with the following columns:
+- Instance ID
+- Instance type
+- Public IP
+- JenkinsJobTag
+- RunByUser
+- keep
+- Name
+- Uptime (calculated as days, hours, and minutes since launch)
+- Keep Status (whether the instance is within or exceeding its 'keep' time in hours)
+
+Each row represents an instance, with tag values filled in or 'N/A' if the tag is missing.
+
+## GitHub Actions Setup
+
+To automate the script to run daily, you can use GitHub Actions. The workflow is configured to run once a day at midnight UTC.
+
+### Setting up Secrets
+
+In your GitHub repository, go to Settings > Secrets and variables > Actions and add the following secrets:
+
+- `AWS_ACCESS_KEY_ID`: Your AWS access key ID
+- `AWS_SECRET_ACCESS_KEY`: Your AWS secret access key
+- `SMTP_SERVER`: SMTP server (e.g., smtp.gmail.com)
+- `SMTP_PORT`: SMTP port (e.g., 587)
+- `SMTP_USER`: SMTP username
+- `SMTP_PASS`: SMTP password
+- `EMAIL_FROM`: Sender email address
+- `EMAIL_TO`: Recipient email addresses (comma-separated for multiple)
+
+### Workflow Details
+
+The workflow file is located at `.github/workflows/daily-run.yml`. It will:
+
+1. Checkout the repository
+2. Set up Python 3.x
+3. Install required dependencies (`boto3`, `tabulate`)
+4. Run the script with the environment variables set from secrets
+
+You can also manually trigger the workflow from the Actions tab in GitHub.
+
+## Notes
+
+- Ensure your AWS credentials have the necessary permissions to describe EC2 instances.
+- The script only shows running instances.

--- a/aws_instance_monitor/aws_instance_monitor.py
+++ b/aws_instance_monitor/aws_instance_monitor.py
@@ -1,0 +1,156 @@
+import boto3
+from tabulate import tabulate
+from datetime import datetime, timezone
+import os
+import smtplib
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+def main():
+    # Create EC2 client
+    ec2 = boto3.client('ec2')
+    
+    # Get all running instances
+    response = ec2.describe_instances(
+        Filters=[
+            {
+                'Name': 'instance-state-name',
+                'Values': ['running']
+            }
+        ]
+    )
+    
+    instances = []
+    instances_to_terminate = []
+    
+    for reservation in response['Reservations']:
+        for instance in reservation['Instances']:
+            tags = {tag['Key']: tag['Value'] for tag in instance.get('Tags', [])}
+            
+            # Calculate uptime
+            launch_time = instance['LaunchTime']
+            uptime_delta = datetime.now(timezone.utc) - launch_time
+            days = uptime_delta.days
+            hours, remainder = divmod(uptime_delta.seconds, 3600)
+            minutes, _ = divmod(remainder, 60)
+            uptime_str = f"{days}d {hours}h {minutes}m"
+            uptime_hours = uptime_delta.total_seconds() / 3600
+            
+            # Check keep status
+            keep_value = tags.get('keep', 'N/A')
+            should_terminate = False
+            if keep_value != 'N/A':
+                try:
+                    keep_hours = float(keep_value)
+                    if uptime_hours > keep_hours:
+                        keep_status = 'Exceeding'
+                        should_terminate = True
+                    else:
+                        keep_status = 'Within'
+                except ValueError:
+                    keep_status = 'Invalid Keep'
+            else:
+                if uptime_hours > 8:
+                    keep_status = 'Exceeding (default 8h)'
+                    should_terminate = True
+                else:
+                    keep_status = 'Within (default 8h)'
+            
+            if should_terminate:
+                instances_to_terminate.append(instance['InstanceId'])
+            
+            row = {
+                'Instance ID': instance['InstanceId'],
+                'Instance type': instance['InstanceType'],
+                'Public IP': instance.get('PublicIpAddress', 'N/A'),
+                'JenkinsJobTag': tags.get('JenkinsJobTag', 'N/A'),
+                'RunByUser': tags.get('RunByUser', 'N/A'),
+                'keep': keep_value,
+                'Name': tags.get('Name', 'N/A'),
+                'Uptime': uptime_str,
+                'Keep Status': keep_status
+            }
+            instances.append(row)
+    
+    # Print the table
+    if instances:
+        table_console = tabulate(instances, headers='keys', tablefmt='simple', maxcolwidths=25)
+        print(table_console)
+    else:
+        print("No running instances found.")
+    
+    # Terminate instances if any
+    if instances_to_terminate:
+        print(f"\nTerminating {len(instances_to_terminate)} instance(s): {', '.join(instances_to_terminate)}")
+        ec2.terminate_instances(InstanceIds=instances_to_terminate)
+        print("Termination initiated.")
+    else:
+        print("\nNo instances to terminate.")
+    
+    # Send email notification
+    smtp_server = os.getenv('SMTP_SERVER')
+    smtp_port = os.getenv('SMTP_PORT', '587')
+    smtp_user = os.getenv('SMTP_USER')
+    smtp_pass = os.getenv('SMTP_PASS')
+    email_from = os.getenv('EMAIL_FROM')
+    email_to_str = os.getenv('EMAIL_TO')
+    if not email_to_str:
+        print("EMAIL_TO not set")
+        email_to = []
+    else:
+        email_to = [addr.strip() for addr in email_to_str.split(',')]
+    
+    if not smtp_server:
+        print("SMTP_SERVER not set")
+    if not smtp_user:
+        print("SMTP_USER not set")
+    if not smtp_pass:
+        print("SMTP_PASS not set")
+    if not email_from:
+        print("EMAIL_FROM not set")
+    
+    if smtp_server and smtp_user and smtp_pass and email_from and email_to and instances:
+        table_html = tabulate(instances, headers='keys', tablefmt='html')
+        html_body = f"""
+        <html>
+        <head>
+        <style>
+        body {{ font-family: Arial, sans-serif; }}
+        h2 {{ color: #333; }}
+        table {{ border-collapse: collapse; width: 100%; margin-top: 20px; }}
+        th, td {{ border: 1px solid #ddd; padding: 8px; text-align: left; }}
+        th {{ background-color: #f2f2f2; font-weight: bold; }}
+        tr:nth-child(even) {{ background-color: #f9f9f9; }}
+        tr:hover {{ background-color: #e9e9e9; }}
+        </style>
+        </head>
+        <body>
+        <h2>AWS Instance Report</h2>
+        {table_html}
+        """
+        if instances_to_terminate:
+            html_body += f"<p>Terminated {len(instances_to_terminate)} instance(s).</p>"
+        html_body += "</body></html>"
+        
+        msg = MIMEMultipart()
+        msg['From'] = email_from
+        msg['To'] = ', '.join(email_to)
+        msg['Subject'] = 'AWS Instance Report'
+        msg.attach(MIMEText(html_body, 'html'))
+        
+        try:
+            print(f"Connecting to {smtp_server}:{smtp_port} with user {smtp_user}")
+            server = smtplib.SMTP(smtp_server, int(smtp_port))
+            server.starttls()
+            server.login(smtp_user, smtp_pass)
+            text = msg.as_string()
+            server.sendmail(email_from, email_to, text)
+            server.quit()
+            print("Email notification sent.")
+        except Exception as e:
+            print(f"Error sending email: {e}")
+    elif smtp_server and not instances:
+        print("No instances to report.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adding a new aws_instance_monitor.py script. This script check once a day for aws instances under releng account, and verify uptime against keep value If the uptime is more then keep value, instnace will be terminate

The reason for such script is to make sure we don't have hang instances that will cost us more then it should

Fixes: PKG-86