### PR TITLE
auto-assign-per-team: remove `releng` team from auto assign

### DIFF
--- a/.github/workflows/auto-assign-per-team.yml
+++ b/.github/workflows/auto-assign-per-team.yml
@@ -13,24 +13,12 @@ jobs:
       fail-fast: false
       matrix:
         team:
-         - releng
          - storage
-#         - core-backend
-#         - core-frontend
          - Drivers-Team
         include:
-          - team: releng
-            project-name: Release_Engineering
-            labels: "[]"
           - team: storage
             project-name: Storage
             labels: "[]"
-#          - team: core-backend
-#            project-name: Core_-_Backend
-#            labels: "['area/materialized views', 'area/udf', 'area/workload prioritization', 'area/ldap', 'area/wasm', 'area/encryption at rest', 'area/workload prioritization', 'area/materialized views', 'area/commitlog hard limit', 'area/commitlog', 'area/sec index']"
-#          - team: core-frontend
-#            project-name: Core_-_Frontend
-#            labels: "['area/guardrails', 'area/security', 'security/audit', 'area/alternator', 'area/alternator-streams']"
           - team: drivers-team
             project-name: Drivers-Team
             labels: "[]"


### PR DESCRIPTION
Since we moved our projects to JIRA

Also removing the comments added to the code for other teams