### PR TITLE
Improve AWS Instance Monitor with dual-schedule reporting system

### DIFF
--- a/.github/workflows/daily-aws-instance-monitor.yml
+++ b/.github/workflows/daily-aws-instance-monitor.yml
@@ -1,13 +1,24 @@
-name: Daily AWS Instance Monitor
+name: AWS Instance Monitor
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Runs daily at midnight UTC
+    - cron: '0 */4 * * *'  # Runs every 4 hours
+    - cron: '0 8 * * *'   # Runs daily at 8 AM UTC for full report
   workflow_dispatch:  # Allows manual triggering
+    inputs:
+      report_type:
+        description: 'Report type (exceeding or daily)'
+        required: false
+        default: 'exceeding'
+        type: choice
+        options:
+          - exceeding
+          - daily
 
 jobs:
-  monitor:
+  monitor-exceeding:
     runs-on: ubuntu-latest
+    if: github.event.schedule == '0 */4 * * *' || (github.event_name == 'workflow_dispatch' && github.event.inputs.report_type == 'exceeding')
 
     steps:
     - name: Checkout repository
@@ -23,7 +34,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install boto3 tabulate
 
-    - name: Run AWS Instance Monitor
+    - name: Run AWS Instance Monitor (Exceeding Only)
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -33,4 +44,36 @@ jobs:
         SMTP_PASS: ${{ secrets.SMTP_PASS }}
         EMAIL_FROM: "it.admin@scylladb.com"
         EMAIL_TO: "releng-team@scylladb.com"
+        REPORT_TYPE: "exceeding"
+      run: python aws_instance_monitor/aws_instance_monitor.py
+
+  monitor-daily:
+    runs-on: ubuntu-latest
+    if: github.event.schedule == '0 8 * * *' || (github.event_name == 'workflow_dispatch' && github.event.inputs.report_type == 'daily')
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install boto3 tabulate
+
+    - name: Run AWS Instance Monitor (Daily Full Report)
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        SMTP_SERVER: "smtp.gmail.com"
+        SMTP_PORT: "587"
+        SMTP_USER: ${{ secrets.SMTP_USER }}
+        SMTP_PASS: ${{ secrets.SMTP_PASS }}
+        EMAIL_FROM: "it.admin@scylladb.com"
+        EMAIL_TO: "releng-team@scylladb.com"
+        REPORT_TYPE: "daily"
       run: python aws_instance_monitor/aws_instance_monitor.py

--- a/aws_instance_monitor/README.md
+++ b/aws_instance_monitor/README.md
@@ -1,6 +1,17 @@
 # AWS Instance Monitor
 
-This Python script retrieves all running EC2 instances in your AWS account and displays them in a table format, including all associated tags.
+This Python script monitors all running EC2 instances across all AWS regions in your account. It provides two types of reports:
+
+1. **Exceeding Instances Report** (runs every 4 hours): Only reports instances that have exceeded their keep time
+2. **Daily Full Report** (runs once per day at 8 AM UTC): Shows all running instances from the last 24 hours
+
+## Features
+
+- Monitors all AWS regions automatically
+- Tracks instance uptime and compares against 'keep' tag values
+- Automatically terminates instances exceeding their keep time
+- Sends email notifications based on report type
+- Provides detailed HTML email reports
 
 ## Prerequisites
 
@@ -19,13 +30,22 @@ This Python script retrieves all running EC2 instances in your AWS account and d
 
 ## Usage
 
+### Local Execution
+
 Run the script using Python:
 
-```
+```bash
+# For exceeding instances report (default)
 python aws_instance_monitor.py
+
+# For daily full report
+REPORT_TYPE=daily python aws_instance_monitor.py
 ```
 
+### Environment Variables
+
 Set the following environment variables for email notifications:
+- `REPORT_TYPE` - Set to `daily` for full report or `exceeding` for exceeding-only report (default: `exceeding`)
 - `SMTP_SERVER` (e.g., smtp.gmail.com)
 - `SMTP_PORT` (e.g., 587)
 - `SMTP_USER`
@@ -33,9 +53,42 @@ Set the following environment variables for email notifications:
 - `EMAIL_FROM`
 - `EMAIL_TO` (comma-separated list of email addresses for multiple recipients)
 
-The script will display the table of running instances and automatically terminate any instances that have exceeded their 'keep' time (in hours) or 8 hours if no 'keep' tag is set.
+### GitHub Actions
 
-**Warning:** This script will terminate EC2 instances. Ensure you have the necessary permissions and that termination is intended.
+The script runs automatically via GitHub Actions:
+- **Every 4 hours**: Checks for instances exceeding keep time and sends alerts
+- **Daily at 8 AM UTC**: Sends comprehensive report of all instances
+
+You can also trigger it manually:
+1. Go to Actions tab in GitHub
+2. Select "AWS Instance Monitor" workflow
+3. Click "Run workflow"
+4. Choose report type (exceeding or daily)
+
+## Report Types
+
+### Exceeding Instances Report
+- Runs every 4 hours
+- Only includes instances that have exceeded their keep time
+- Email sent only if there are exceeding instances
+- Terminates instances that exceed their keep time
+
+### Daily Full Report
+- Runs once per day at 8 AM UTC
+- Includes all running instances
+- Shows comprehensive statistics:
+  - Total running instances
+  - Number of instances exceeding keep time
+  - Number of terminated instances
+- Email always sent if there are any instances
+
+## Instance Keep Time
+
+The script uses the `keep` tag on EC2 instances to determine how long they should run:
+- If `keep` tag exists: Uses the value (in hours)
+- If no `keep` tag: Defaults to 8 hours
+
+**Warning:** This script will automatically terminate EC2 instances that exceed their keep time. Ensure you have the necessary permissions and that termination is intended.
 
 The script will output a table with the following columns:
 - Instance ID


### PR DESCRIPTION
This commit introduces a smarter reporting system that reduces email noise while maintaining comprehensive visibility of AWS EC2 instances.

Key improvements:

1. Dual Schedule System
   - Every 4 hours: Check for instances exceeding keep time
   - Daily at 8 AM UTC: Comprehensive report of all instances

2. Smart Email Notifications
   - Exceeding reports: Email sent ONLY when instances exceed keep time
   - Daily reports: Always sent with full 24-hour overview
   - Different subject lines for easy identification:
     * "AWS Instance Alert - Instances Exceeding Keep Time"
     * "Daily AWS Instance Report - All Instances (Last 24 Hours)"