### PR TITLE
PM-49 Update the Jira issue status only if it is different from the current one

### DIFF
--- a/.github/workflows/extract_jira_issue_details.yml
+++ b/.github/workflows/extract_jira_issue_details.yml
@@ -1,0 +1,64 @@
+name: Fetch Jira Issue Details
+
+on:
+  workflow_call:
+    inputs:
+      jira_key:
+        type: string
+        required: true
+    secrets:
+      jira_auth:
+        required: true
+    outputs:
+      current_jira_status:
+        value: ${{ jobs.fetch.outputs.current_status }}
+      current_jira_priority:
+        value: ${{ jobs.fetch.outputs.priority }}
+      current_jira_labels:
+        value: ${{ jobs.fetch.outputs.labels }}
+
+jobs:
+  fetch:
+    runs-on: ubuntu-latest
+    outputs:
+      current_status: ${{ steps.jira.outputs.status }}
+      priority: ${{ steps.jira.outputs.priority }}
+      labels: ${{ steps.jira.outputs.labels }}
+    steps:
+    
+      - name: Ensure jq is available
+        run: |
+          if ! command -v jq >/dev/null 2>&1; then
+            sudo apt-get update -y
+            sudo apt-get install -y jq
+          fi
+
+      - name: Fetch Jira issue details
+        id: jira
+        env:
+          JIRA_AUTH: ${{ secrets.jira_auth }}
+          JIRA_KEY: ${{ inputs.jira_key }}
+        run: |
+          set -euo pipefail
+
+          echo "Fetching ${JIRA_KEY} from Jira ..."
+          RESP="$(curl -sS \
+                  --user "$JIRA_AUTH" \
+                  -H "Accept: application/json" \
+                  "https://scylladb.atlassian.net/rest/api/3/issue/${JIRA_KEY}?fields=status,priority,labels")"
+        
+          # Extract fields (priority may be null)
+          STATUS="$(echo "$RESP" | jq -r '.fields.status.name // ""')"
+          PRIORITY="$(echo "$RESP" | jq -r '.fields.priority.name // ""')"
+          LABELS="$(echo "$RESP" | jq -r '(.fields.labels // []) | join(",")')"
+
+
+          echo "Current status: ${STATUS}"
+          echo "Priority: ${PRIORITY}"
+          echo "Labels: ${LABELS}"
+
+          {
+            echo "status=${STATUS}"
+            echo "priority=${PRIORITY}"
+            echo "labels=${LABELS}"
+          } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/jira_transition.yml
+++ b/.github/workflows/jira_transition.yml
@@ -12,6 +12,9 @@ on:
       transition_id:
         required: true
         type: string
+      current_jira_status:
+        required: false
+        type: string
     secrets:
       jira_auth:
         required: true
@@ -20,8 +23,28 @@ jobs:
   transition:
     if: ${{ inputs.jira_key != '' && inputs.jira_key != '__NO_KEYS_FOUND__' }}
     runs-on: ubuntu-latest
-    steps:
+    steps:     
+      - name: Show intent
+        run: |
+          key="${{ inputs.jira_key }}"
+          target="${{ inputs.transition_name }}"
+          current="${{ inputs.current_jira_status }}"
+          id="${{ inputs.transition_id }}"
+
+          echo "Jira key:         ${key}"
+          echo "Target status:    ${target}"
+          echo "Current status:   ${current}"
+          echo "Transition ID:    ${id}"
+
+          # If/else with proper closing 'fi'
+          if [ -n "$current" ] && [ "$current" = "$target" ]; then
+            echo "Skipping transition for ${key} — already at desired status '${current}'."
+          else
+            echo "We are going to transition ${key} from '${current}' to '${target}'."
+          fi
+          
       - name: Transition Jira Ticket
+        if: ${{ inputs.current_jira_status == '' || inputs.current_jira_status != inputs.transition_name }}
         env:
           JIRA_AUTH: ${{ secrets.jira_auth }}
         run: |

--- a/.github/workflows/main_update_jira_status_to_in_progress.yml
+++ b/.github/workflows/main_update_jira_status_to_in_progress.yml
@@ -13,8 +13,8 @@ jobs:
       pr_title: ${{ github.event.pull_request.title }}
       pr_body:  ${{ github.event.pull_request.body }}
 
-  debug:
-    needs: extract
+  debug:                         
+    needs: extract               
     runs-on: ubuntu-latest
     steps:
       - name: Debug data
@@ -27,13 +27,33 @@ jobs:
           echo "~~~~~~~~~~~ GitHub Context ~~~~~~~~~~~"
           echo "$GITHUB_CONTEXT"
 
-  transition:
+  # Retrieve details per jira key
+  details:
     needs: extract
+    uses: scylladb/github-automation/.github/workflows/extract_jira_issue_details.yml@main
+    secrets:
+      jira_auth: ${{ secrets.caller_jira_auth }}
+    strategy:
+      matrix:
+        jira_key: ${{ fromJSON(
+          (needs.extract.outputs['jira-keys-json'] != '' &&
+           needs.extract.outputs['jira-keys-json'] != '[]' &&
+           needs.extract.outputs['jira-keys-json'] != '[""]')
+            && needs.extract.outputs['jira-keys-json']
+            || '["__NO_KEYS_FOUND__"]') }}
+        exclude:
+          - jira_key: "__NO_KEYS_FOUND__"
+    with:
+      jira_key: ${{ matrix.jira_key }}
+
+  transition:
+    needs: [extract, details]
     uses: scylladb/github-automation/.github/workflows/jira_transition.yml@main
     with:
       jira_key: ${{ matrix.jira_key }}
       transition_name: "In Progress"
       transition_id: "111"
+      current_jira_status:   ${{ needs.details.outputs.current_jira_status }}
     secrets:
       jira_auth: ${{ secrets.caller_jira_auth }}
     strategy:

--- a/.github/workflows/main_update_jira_status_to_in_review.yml
+++ b/.github/workflows/main_update_jira_status_to_in_review.yml
@@ -13,10 +13,10 @@ jobs:
       pr_title: ${{ github.event.pull_request.title }}
       pr_body:  ${{ github.event.pull_request.body }}
 
-  debug:
-    needs: extract
+  debug:                         
+    needs: extract               
     runs-on: ubuntu-latest
-    steps:
+    steps:       
       - name: Debug data
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
@@ -26,14 +26,34 @@ jobs:
           echo "jira-keys-json='${{ needs.extract.outputs['jira-keys-json'] }}'"
           echo "~~~~~~~~~~~ GitHub Context ~~~~~~~~~~~"
           echo "$GITHUB_CONTEXT"
+          
+  # Retrieve details per jira key
+  details:
+    needs: extract
+    uses: scylladb/github-automation/.github/workflows/extract_jira_issue_details.yml@main
+    secrets:
+      jira_auth: ${{ secrets.caller_jira_auth }}
+    strategy:
+      matrix:
+        jira_key: ${{ fromJSON(
+          (needs.extract.outputs['jira-keys-json'] != '' &&
+           needs.extract.outputs['jira-keys-json'] != '[]' &&
+           needs.extract.outputs['jira-keys-json'] != '[""]')
+            && needs.extract.outputs['jira-keys-json']
+            || '["__NO_KEYS_FOUND__"]') }}
+        exclude:
+          - jira_key: "__NO_KEYS_FOUND__"
+    with:
+      jira_key: ${{ matrix.jira_key }}
 
   transition:
-    needs: extract
+    needs: [extract, details]
     uses: scylladb/github-automation/.github/workflows/jira_transition.yml@main
     with:
       jira_key: ${{ matrix.jira_key }}
       transition_name: "In Review"
       transition_id: "121"
+      current_jira_status:   ${{ needs.details.outputs.current_jira_status }}
     secrets:
       jira_auth: ${{ secrets.caller_jira_auth }}
     strategy:

--- a/.github/workflows/main_update_jira_status_to_ready_for_merge.yml
+++ b/.github/workflows/main_update_jira_status_to_ready_for_merge.yml
@@ -13,29 +13,56 @@ jobs:
       pr_title: ${{ github.event.pull_request.title }}
       pr_body:  ${{ github.event.pull_request.body }}
 
-  debug:
-    needs: extract
+  debug:                         
+    needs: extract               
     runs-on: ubuntu-latest
-    steps:
+    steps:       
       - name: Debug data
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: |
+        run: |         
           echo "event_name='${{ github.event_name }}'"
           echo "action='${{ github.event.action }}'"
           echo "jira-keys-json='${{ needs.extract.outputs['jira-keys-json'] }}'"
           echo "triggering-label='${{ github.event.label.name }}'"
+          label="${{ github.event.label.name }}"
+                    
+          if [ -n "$label" ] && [ "$label" = "status/merge_candidate" ]; then
+            echo "Try to transition Jira issue to 'Ready For Merge'"
+          fi
+          
           echo "~~~~~~~~~~~ GitHub Context ~~~~~~~~~~~"
           echo "$GITHUB_CONTEXT"
 
-  transition:
+
+  # Retrieve details per jira key
+  details:
     needs: extract
+    uses: scylladb/github-automation/.github/workflows/extract_jira_issue_details.yml@main
+    secrets:
+      jira_auth: ${{ secrets.caller_jira_auth }}
+    strategy:
+      matrix:
+        jira_key: ${{ fromJSON(
+          (needs.extract.outputs['jira-keys-json'] != '' &&
+           needs.extract.outputs['jira-keys-json'] != '[]' &&
+           needs.extract.outputs['jira-keys-json'] != '[""]')
+            && needs.extract.outputs['jira-keys-json']
+            || '["__NO_KEYS_FOUND__"]') }}
+        exclude:
+          - jira_key: "__NO_KEYS_FOUND__"
+    with:
+      jira_key: ${{ matrix.jira_key }}
+
+  transition:
+    needs: [extract, details]
     if: ${{ github.event.label.name == 'status/merge_candidate' }}
     uses: scylladb/github-automation/.github/workflows/jira_transition.yml@main
     with:
       jira_key: ${{ matrix.jira_key }}
       transition_name: "Ready For Merge"
       transition_id: "131"
+      current_jira_status:   ${{ needs.details.outputs.current_jira_status }}
     secrets:
       jira_auth: ${{ secrets.caller_jira_auth }}
     strategy:


### PR DESCRIPTION
1. Create a new file that collects information from Jira. For this use case, status is relevant.
2. update the transition module to check if the current status and the target status are different before commiting the transition 
3. update the 3 main files to extract jira issue details and pass to the transition module.

Fixes: PM-49