### PR TITLE
Add a use cases of reading jira keys from the PR body

### DIFF
--- a/.github/workflows/extract_jira_keys.yml
+++ b/.github/workflows/extract_jira_keys.yml
@@ -46,7 +46,7 @@ jobs:
           
           > tickets.txt
           printf '%s\n' "$title" | grep -oE '[A-Z]+-[0-9]+' >> tickets.txt || true
-          printf '%s\n' "$body"  | grep -iE '(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)[[:space:]]*[: ][[:space:]]*((https?://[^[:space:]]*/browse/)?[A-Z]+-[0-9]+)' \
+          printf '%s\n' "$body"  | grep -iE '(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)[[:space:]]*[: ][[:space:]]*\[?[[:space:]]*((https?://[^[:space:]]*/browse/)?[A-Z]+-[0-9]+)' \
                                 | grep -oE '[A-Z]+-[0-9]+' >> tickets.txt || true
 
           sort -u tickets.txt > unique_tickets.txt


### PR DESCRIPTION
Adding a use case to extract jira keys from the PR body when the Jira key is translated in markdown to:
```
 Fixes: [VECTOR-156](https://scylladb.atlassian.net/browse/VECTOR-156)

[VECTOR-156]: https://scylladb.atlassian.net/browse/VECTOR-156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
```

Fixes: PM-63