### PR TITLE
Add PR url to a jira field, to allow Jira automation to close only issues which were marked for closing by the PR merge

### DIFF
--- a/.github/workflows/fill_jira_with_github_data.yml
+++ b/.github/workflows/fill_jira_with_github_data.yml
@@ -1,0 +1,150 @@
+name: Fill Jira Field with GitHub PR Data
+
+on:
+  workflow_call:
+    inputs:
+      details_csv:
+        description: "Full CSV text (header + rows). Must include a 'key' column."
+        required: true
+        type: string
+    secrets:
+      jira_auth:
+        description: "Plain 'email:api_token' for Jira Cloud Basic auth"
+        required: true
+
+jobs:
+  fill_field:
+    runs-on: ubuntu-latest
+    env:
+      BASE_URL: https://scylladb.atlassian.net
+      TARGET_FIELD: customfield_10718
+      PR_URL: ${{ github.event.pull_request.html_url }}
+
+    steps:
+      - name: Save CSV
+        id: save
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > details.csv <<'CSV_EOF'
+          ${{ inputs.details_csv }}
+          CSV_EOF
+
+          echo "Saved details.csv"
+          head -n 5 details.csv || true
+
+      - name: Extract Jira keys (case-insensitive 'key' column)
+        id: extract
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          python3 - <<'PY'
+          import csv, sys, os
+
+          if not os.path.exists("details.csv") or os.path.getsize("details.csv") == 0:
+              print("CSV empty → no keys to process.")
+              open("keys.txt", "w").close()
+              sys.exit(0)
+
+          with open("details.csv", newline="", encoding="utf-8") as f:
+              reader = csv.DictReader(f)
+              if not reader.fieldnames:
+                  open("keys.txt", "w").close()
+                  sys.exit(0)
+
+              # Find the 'key' column
+              fmap = {(h or "").strip().lower(): h for h in reader.fieldnames}
+              hkey = fmap.get("key")
+              if not hkey:
+                  print(f"ERROR: No 'key' column. Found: {reader.fieldnames}", file=sys.stderr)
+                  sys.exit(1)
+
+              keys = []
+              for row in reader:
+                  val = (row.get(hkey) or "").strip()
+                  if val:
+                      keys.append(val)
+
+          seen = set()
+          uniq = []
+          for k in keys:
+              if k not in seen:
+                  uniq.append(k)
+                  seen.add(k)
+
+          with open("keys.txt", "w") as out:
+              for k in uniq:
+                  out.write(k + "\n")
+
+          print(f"Found {len(uniq)} Jira issues.")
+          PY
+
+          echo "First few keys:"
+          head -n 10 keys.txt || true
+
+      - name: Write PR data to Jira custom field
+        shell: bash
+        env:
+          JIRA_AUTH: ${{ secrets.jira_auth }}
+          PR_URL:   ${{ env.PR_URL }}
+          BASE_URL: ${{ env.BASE_URL }}
+          FIELD_ID: ${{ env.TARGET_FIELD }}
+        run: |
+          set -euo pipefail
+
+          if [ ! -s keys.txt ]; then
+            echo "No keys found. Done."
+            exit 0
+          fi
+
+          COMMENT_TEXT="This issue will be closed by ${PR_URL}"
+
+          while IFS= read -r key; do
+            [ -n "$key" ] || continue
+
+            echo "Updating $key - [ $COMMENT_TEXT ]"
+
+            # Build ADF document payload for rich-text custom field
+            jq -n \
+              --arg text "$COMMENT_TEXT" \
+              --arg field "$FIELD_ID" \
+              '{
+                fields: {
+                  ($field): {
+                    "type": "doc",
+                    "version": 1,
+                    "content": [
+                      {
+                        "type": "paragraph",
+                        "content": [
+                          {
+                            "type": "text",
+                            "text": $text
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }' > payload.json
+
+            code=$(curl -sS -o resp.json -w "%{http_code}" \
+              -X PUT "$BASE_URL/rest/api/3/issue/$key" \
+              --user "$JIRA_AUTH" \
+              -H "Content-Type: application/json" \
+              --data @payload.json)
+
+            if [[ "$code" == "204" || "$code" == "200" ]]; then
+              echo "OK $key (${code})"
+            else
+              echo "FAIL $key (${code})"
+              head -c 200 resp.json || true
+              echo
+              exit 1
+            fi
+
+            sleep 0.2
+          done < keys.txt
+
+          echo "All Jira fields updated successfully."

--- a/.github/workflows/main_update_jira_status_to_in_progress.yml
+++ b/.github/workflows/main_update_jira_status_to_in_progress.yml
@@ -54,3 +54,12 @@ jobs:
       transition_id:   "111"
     secrets:
       jira_auth: ${{ secrets.caller_jira_auth }}
+
+
+  fill_field:
+    needs: [extract, details]
+    uses: scylladb/github-automation/.github/workflows/fill_jira_with_github_data.yml@main
+    with:
+      details_csv: ${{ needs.details.outputs.csv }}
+    secrets:
+      jira_auth: ${{ secrets.caller_jira_auth }}

--- a/.github/workflows/main_update_jira_status_to_in_review.yml
+++ b/.github/workflows/main_update_jira_status_to_in_review.yml
@@ -53,3 +53,12 @@ jobs:
       transition_id: "121"
     secrets:
       jira_auth: ${{ secrets.caller_jira_auth }}
+
+
+  fill_field:
+    needs: [extract, details]
+    uses: scylladb/github-automation/.github/workflows/fill_jira_with_github_data.yml@main
+    with:
+      details_csv: ${{ needs.details.outputs.csv }}
+    secrets:
+      jira_auth: ${{ secrets.caller_jira_auth }}

--- a/.github/workflows/main_update_jira_status_to_ready_for_merge.yml
+++ b/.github/workflows/main_update_jira_status_to_ready_for_merge.yml
@@ -70,3 +70,11 @@ jobs:
       transition_id: "121"
     secrets:
       jira_auth: ${{ secrets.caller_jira_auth }}
+
+  fill_field:
+    needs: [extract, details]
+    uses: scylladb/github-automation/.github/workflows/fill_jira_with_github_data.yml@main
+    with:
+      details_csv: ${{ needs.details.outputs.csv }}
+    secrets:
+      jira_auth: ${{ secrets.caller_jira_auth }}


### PR DESCRIPTION
By sending Jira only the PR urls that this PR fixes, it will allow the Jira automation to close only issues that were specifically asked to be closed, and not regular mentions of Jira keys.

Adding a new file: fill_jira_with_github_data.yml, to add the details of the PR url, only for issues that were marked as 'Fixes', 'Resolved' etc.
This new logic is called by the three main syncs, during PR creation, PR review and PR request to merge.

This scenario was tested, with the Jira automation, in staging.git and the STAG jira project. 

Fixes: PM-57
Fixes: PM-45