### PR TITLE
Sync priority and area labels

### DIFF
--- a/.github/workflows/add_label_to_jira_issue.yml
+++ b/.github/workflows/add_label_to_jira_issue.yml
@@ -8,7 +8,7 @@ on:
         type: string
         required: true
       label:
-        description: "Label to add to each Jira issue, or P0..P4 to set priority"
+        description: "Label to add to each Jira issue, or P0..P4 to set priority, or area/* to add Scylla component"
         type: string
         required: true
     secrets:
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BASE_URL: https://scylladb.atlassian.net
+      SCYLLA_COMPONENTS_FIELD: customfield_10321
 
     steps:
       - name: Save CSV
@@ -47,7 +48,6 @@ jobs:
           # NEW: If file is missing or truly empty -> log and skip
           if not os.path.exists("details.csv") or os.path.getsize("details.csv") == 0:
               print("details.csv is empty or missing; no issues to update.")
-              # Ensure keys.txt exists and is empty so the next step can short-circuit cleanly
               open("keys.txt", "w", encoding="utf-8").close()
               sys.exit(0)
 
@@ -62,7 +62,6 @@ jobs:
               fmap = { (h or "").strip().lower(): h for h in r.fieldnames }  # case-insensitive
               hkey = fmap.get("key")
               if not hkey:
-                  # This remains a hard error: non-empty CSV but missing required column
                   print(f"ERROR: CSV header must include a 'key' column. Found: {r.fieldnames}", file=sys.stderr)
                   sys.exit(1)
 
@@ -71,7 +70,6 @@ jobs:
                   if k:
                       keys.append(k)
 
-          # ORIGINAL LOGIC: de-duplicate, preserve order
           seen = set()
           uniq = []
           for k in keys:
@@ -88,25 +86,46 @@ jobs:
           echo "First 10 keys:"
           head -n 10 keys.txt || true
 
-      - name: Prepare payload(s) and mode (no heredocs)
+      - name: Prepare payload(s) and mode (priority / label / scylla component)
         id: prep
         shell: bash
         env:
-          TARGET_IN: ${{ inputs.label }}
+          TARGET_IN:  ${{ inputs.label }}
+          SCYLLA_FIELD: ${{ env.SCYLLA_COMPONENTS_FIELD }}
         run: |
           set -euo pipefail
 
-          # Normalize to uppercase for P0..P4 detection
           TARGET_UP=$(echo "${TARGET_IN}" | tr '[:lower:]' '[:upper:]')
 
+          MODE=""
+          PRIORITY_NAME=""
+          echo "Incoming label: '${TARGET_IN}'"
+
+          # 1) P0..P4 → priority field
           case "$TARGET_UP" in
             P0|P1|P2|P3|P4)
               MODE="priority"
               PRIORITY_NAME="$TARGET_UP"
               ;;
             *)
-              MODE="label"
-              PRIORITY_NAME=""
+              # 2) area/* → scylla_components
+              if [[ "$TARGET_IN" == area/* ]]; then
+                MODE="scylla_component"
+                RAW="${TARGET_IN#area/}"
+                # Replace underscores with spaces across the entire remainder
+                COMPONENT_VALUE="${RAW//_/ }"
+
+                echo "Derived Scylla component value: '${COMPONENT_VALUE}' from label '${TARGET_IN}'"
+
+                # JSON-escape the component value
+                ESCAPED=$(jq -Rn --arg v "$COMPONENT_VALUE" '$v')
+                # Build payload: update customfield_10321 with add { value: "<component>" }
+                printf '{"update":{"%s":[{"add":{"value":%s}}]}}\n' "$SCYLLA_FIELD" "$ESCAPED" > payload_scylla.json
+                echo "Scylla components payload ready."
+              else
+                # 3) Fallback: normal Jira label
+                MODE="label"
+              fi
               ;;
           esac
 
@@ -114,9 +133,11 @@ jobs:
           echo "priority_name=${PRIORITY_NAME}" >> "$GITHUB_OUTPUT"
 
           # Build the label payload with jq (used when MODE=label)
-          jq -n --arg label "$TARGET_IN" \
-            '{update:{labels:[{add:$label}]}}' > payload_label.json
-          echo "Label payload ready."
+          if [ "$MODE" = "label" ]; then
+            jq -n --arg label "$TARGET_IN" \
+              '{update:{labels:[{add:$label}]}}' > payload_label.json
+            echo "Label payload ready."
+          fi
 
           # Build the priority payload with jq (used when MODE=priority)
           if [ "$MODE" = "priority" ]; then
@@ -147,6 +168,10 @@ jobs:
             echo "Will set priority to: ${PRIORITY_NAME}"
             PAYLOAD_FILE="payload_priority.json"
             ACTION_DESC="Set priority"
+          elif [ "$MODE" = "scylla_component" ]; then
+            echo "Will add Scylla component derived from label: ${TARGET_LABEL}"
+            PAYLOAD_FILE="payload_scylla.json"
+            ACTION_DESC="Add Scylla component"
           else
             echo "Will add label: ${TARGET_LABEL}"
             PAYLOAD_FILE="payload_label.json"
@@ -163,7 +188,6 @@ jobs:
 
             echo "${ACTION_DESC} on ${key} ..."
 
-            # Perform update (Basic auth via --user)
             code=$(curl -sS -o resp.json -w "%{http_code}" \
               -X PUT "${ISSUE_URL}" \
               --user "$JIRA_AUTH" \
@@ -171,15 +195,22 @@ jobs:
               -H "Content-Type: application/json" \
               --data @"${PAYLOAD_FILE}")
 
-            # Jira: 204 No Content (common) or 200 OK
             if [ "$code" = "204" ] || [ "$code" = "200" ]; then
               echo "OK ${key} (${code})"
               ok=$((ok+1))
+
             elif [ "$code" = "400" ] && [ "$MODE" = "label" ]; then
               # Often returned if label already present; treat as skip for labels
               echo "SKIP ${key} (${code}) likely already has the label. First 200 chars:"
               head -c 200 resp.json || true; echo
               skipped=$((skipped+1))
+
+            elif [ "$code" = "400" ] && [ "$MODE" = "scylla_component" ]; then
+              # Option value not valid for scylla_components – log and skip
+              echo "SKIP ${key} (${code}) invalid Scylla component option. First 200 chars:"
+              head -c 200 resp.json || true; echo
+              skipped=$((skipped+1))
+
             else
               echo "FAIL ${key} (${code}) First 400 chars:"
               head -c 400 resp.json || true; echo

--- a/.github/workflows/apply_labels_to_pr.yml
+++ b/.github/workflows/apply_labels_to_pr.yml
@@ -11,6 +11,10 @@ on:
         description: "Comma-separated labels string (e.g. 'bug, needs-triage, backend')"
         type: string
         required: true
+      details_csv:
+        description: "Full CSV from Jira details (header + rows). Must include 'priority' and 'scylla_components' columns."
+        type: string
+        required: true
 
 permissions:
   contents: read
@@ -21,24 +25,94 @@ jobs:
   apply:
     runs-on: ubuntu-latest
     steps:
-      - name: Prepare labels list (trim, dedupe, ignore empties)
+      - name: Prepare labels list (trim, dedupe, ignore empties, compute P* & area/* from Jira)
         id: prepare
         env:
-          LABELS_CSV: ${{ inputs.labels_csv }}
+          LABELS_CSV:  ${{ inputs.labels_csv }}
+          DETAILS_CSV: ${{ inputs.details_csv }}
         run: |
           set -euo pipefail
           python3 - <<'PY'
-          import os
-          csv = os.environ.get("LABELS_CSV","")
-          seen, out = set(), []
-          for raw in csv.split(","):
-              s = raw.strip()
+          import os, io, csv, re
+
+          labels_csv = os.environ.get("LABELS_CSV", "")
+          details_csv = os.environ.get("DETAILS_CSV", "")
+
+          # 1) Parse labels_csv into a deduped list
+          raw_labels = [s.strip() for s in labels_csv.split(",")]
+          seen = set()
+          labels = []
+          for s in raw_labels:
               if s and s not in seen:
                   seen.add(s)
-                  out.append(s)
-          print("Parsed labels:", out)
+                  labels.append(s)
+
+          # 2) Remove any existing P0..P4 from this base list
+          priority_labels = {"P0", "P1", "P2", "P3", "P4"}
+          labels = [l for l in labels if l not in priority_labels]
+
+          # 3) Prepare to compute Jira-based priority and area/* labels
+          priority_rank_map = {
+              "p0": 0, "highest": 0, "blocker": 0,
+              "p1": 1, "critical": 1, "high": 1,
+              "p2": 2, "medium": 2, "major": 2,
+              "p3": 3, "low": 3, "minor": 3,
+              "p4": 4, "lowest": 4, "trivial": 4,
+          }
+
+          best_rank = None
+          area_labels = []
+          area_seen = set()
+
+          details_csv = details_csv.strip()
+          if details_csv:
+              reader = csv.DictReader(io.StringIO(details_csv))
+              for row in reader:
+                  # ----- priority → P* -----
+                  prio = (row.get("priority") or "").strip()
+                  if prio:
+                      key = prio.lower()
+                      rank = priority_rank_map.get(key)
+                      if rank is not None:
+                          if best_rank is None or rank < best_rank:
+                              best_rank = rank
+
+                  # ----- scylla_components → area/* labels -----
+                  comp_raw = (row.get("scylla_components") or "").strip()
+                  if comp_raw:
+                      # components are ";"-separated in the CSV we build
+                      for part in comp_raw.split(";"):
+                          comp = part.strip()
+                          if not comp:
+                              continue
+                          # Replace whitespace with underscores
+                          safe = re.sub(r"\s+", "_", comp)
+                          label = f"area/{safe}"
+                          if label not in area_seen:
+                              area_seen.add(label)
+                              area_labels.append(label)
+
+          # 4) Add computed P* label (if any) at the front
+          priority_label = None
+          if best_rank is not None:
+              priority_label = f"P{best_rank}"
+
+          if priority_label:
+              print(f"Computed priority label from Jira: {priority_label}")
+              if priority_label not in labels:
+                  labels.insert(0, priority_label)
+          else:
+              print("No mappable Jira priority found; not adding P* label.")
+
+          # 5) Append area/* labels (dedup vs other labels)
+          for area in area_labels:
+              if area not in labels:
+                  labels.append(area)
+
+          print("Final labels to apply:", labels)
+
           with open("labels.txt", "w", encoding="utf-8") as f:
-              for l in out:
+              for l in labels:
                   f.write(l + "\n")
           PY
 
@@ -49,11 +123,42 @@ jobs:
             exit 0
           fi
 
-      - name: Add labels (no pre-checks)
+      - name: Remove existing P0–P4 labels from PR
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN:   ${{ github.token }}
           OWNER_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ inputs.pr_number }}
+          PR_NUMBER:  "${{ inputs.pr_number }}"
+        run: |
+          set -euo pipefail
+
+          ISSUE_API_BASE="https://api.github.com/repos/${OWNER_REPO}/issues/${PR_NUMBER}"
+
+          echo "Fetching existing labels for PR #${PR_NUMBER}..."
+          curl -sS \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "${ISSUE_API_BASE}/labels" > /tmp/existing_labels.json
+
+          jq -r '.[].name' /tmp/existing_labels.json > existing_labels.txt || true
+
+          for p in P0 P1 P2 P3 P4; do
+            if grep -qx "$p" existing_labels.txt 2>/dev/null; then
+              echo "Removing existing label: $p"
+              code=$(curl -sS -o /tmp/del_resp.json -w "%{http_code}" \
+                -X DELETE "${ISSUE_API_BASE}/labels/${p}" \
+                -H "Authorization: Bearer ${GH_TOKEN}" \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" || true)
+              echo "Delete $p → HTTP ${code}"
+            fi
+          done
+
+      - name: Add labels (after priority & area/* normalization)
+        env:
+          GH_TOKEN:   ${{ github.token }}
+          OWNER_REPO: ${{ github.repository }}
+          PR_NUMBER:  "${{ inputs.pr_number }}"
         run: |
           set -euo pipefail
           ISSUE_API="https://api.github.com/repos/${OWNER_REPO}/issues/${PR_NUMBER}/labels"

--- a/.github/workflows/main_update_jira_status_to_in_progress.yml
+++ b/.github/workflows/main_update_jira_status_to_in_progress.yml
@@ -44,6 +44,7 @@ jobs:
     with:
       pr_number:  ${{ github.event.pull_request.number }}
       labels_csv: ${{ needs.details.outputs.labels_csv }}
+      details_csv: ${{ needs.details.outputs.csv }}
 
   transition:
     needs: [extract, details]

--- a/.github/workflows/main_update_jira_status_to_in_review.yml
+++ b/.github/workflows/main_update_jira_status_to_in_review.yml
@@ -43,6 +43,7 @@ jobs:
     with:
       pr_number:  ${{ github.event.pull_request.number }}
       labels_csv: ${{ needs.details.outputs.labels_csv }}
+      details_csv: ${{ needs.details.outputs.csv }}
 
   transition:
     needs: [extract, details]

--- a/.github/workflows/main_update_jira_status_to_ready_for_merge.yml
+++ b/.github/workflows/main_update_jira_status_to_ready_for_merge.yml
@@ -14,7 +14,7 @@ jobs:
       pr_body:  ${{ github.event.pull_request.body }}
     secrets:
       jira_auth: ${{ secrets.caller_jira_auth }}
-
+      
   debug:                         
     needs: extract               
     runs-on: ubuntu-latest
@@ -60,6 +60,7 @@ jobs:
     with:
       pr_number:  ${{ github.event.pull_request.number }}
       labels_csv: ${{ needs.details.outputs.labels_csv }}
+      details_csv: ${{ needs.details.outputs.csv }}
 
   transition:
     needs: [extract, details]


### PR DESCRIPTION
The automation workflow will:

1. Sync the priority Jira field with the P0-P4 labels
2. Sync the Scylla components Jira field with the 'area/*' labels in GitHub.

- The change includes adding the whole csv file, with Jira issue data, to the module that creates labels based on Jira issue data, and to the code that updates Jira based on the GitHub labels.

Fixes: PM-50
Fixes: PM-55