### PR TITLE
feat(PM-279): scan PR commit messages for Jira keys

### DIFF
--- a/scripts/jira_sync_logic.py
+++ b/scripts/jira_sync_logic.py
@@ -76,7 +76,10 @@ def manage_labeled_gh_event(
     print("=" * 60)
     print(" Step 1 / extract_jira_keys")
     print("=" * 60)
-    keys = extract_jira_keys(pr_title, pr_body, jira_auth)
+    keys = extract_jira_keys(pr_title, pr_body, jira_auth,
+                             owner_repo=owner_repo,
+                             pr_number=pr_number,
+                             gh_token=gh_token)
     jira_keys_json = json.dumps(keys)
     print(f"jira-keys-json={jira_keys_json}")
 
@@ -249,7 +252,10 @@ def manage_review_gh_event(
     print("\n" + "=" * 60)
     print(" Step 1 / extract_jira_keys")
     print("=" * 60)
-    keys = extract_jira_keys(pr_title, pr_body, jira_auth)
+    keys = extract_jira_keys(pr_title, pr_body, jira_auth,
+                             owner_repo=owner_repo,
+                             pr_number=pr_number,
+                             gh_token=gh_token)
     jira_keys_json = json.dumps(keys)
     print(f"jira-keys-json={jira_keys_json}")
 
@@ -366,7 +372,10 @@ def manage_closed_gh_event(
     print("\n" + "=" * 60)
     print(" Step 1 / extract_jira_keys")
     print("=" * 60)
-    keys = extract_jira_keys(pr_title, pr_body, jira_auth)
+    keys = extract_jira_keys(pr_title, pr_body, jira_auth,
+                             owner_repo=owner_repo,
+                             pr_number=pr_number,
+                             gh_token=gh_token)
     jira_keys_json = json.dumps(keys)
     print(f"jira-keys-json={jira_keys_json}")
 
@@ -506,7 +515,10 @@ def manage_opened_gh_event(
     print("\n" + "=" * 60)
     print(" Step 1 / extract_jira_keys")
     print("=" * 60)
-    keys = extract_jira_keys(pr_title, pr_body, jira_auth)
+    keys = extract_jira_keys(pr_title, pr_body, jira_auth,
+                             owner_repo=owner_repo,
+                             pr_number=pr_number,
+                             gh_token=gh_token)
     jira_keys_json = json.dumps(keys)
     print(f"jira-keys-json={jira_keys_json}")
 
@@ -625,7 +637,10 @@ def manage_unlabeled_gh_event(
     print("\n" + "=" * 60)
     print(" Step 1 / extract_jira_keys")
     print("=" * 60)
-    keys = extract_jira_keys(pr_title, pr_body, jira_auth)
+    keys = extract_jira_keys(pr_title, pr_body, jira_auth,
+                             owner_repo=owner_repo,
+                             pr_number=pr_number,
+                             gh_token=gh_token)
     jira_keys_json = json.dumps(keys)
     print(f"jira-keys-json={jira_keys_json}")
 

--- a/scripts/jira_sync_modules.py
+++ b/scripts/jira_sync_modules.py
@@ -65,9 +65,9 @@ def _sanitize(text: str) -> str:
     return text.replace('\r', '').replace('`', ' ')
 
 
-def _extract_candidate_keys(pr_body: str) -> list[str]:
+def _extract_candidate_keys(text: str) -> list[str]:
     """
-    Extract candidate Jira keys from the PR body.
+    Extract candidate Jira keys from arbitrary text (PR body, commit message).
 
     Only keys preceded by a closing keyword (Fixes, Closes, Resolves, etc.)
     are accepted. Bare key mentions are ignored.
@@ -75,9 +75,9 @@ def _extract_candidate_keys(pr_body: str) -> list[str]:
     """
     candidates: set[str] = set()
 
-    body = _sanitize(pr_body)
+    body = _sanitize(text)
 
-    # Closing-keyword keys from body (Fixes, Closes, Resolves, etc.)
+    # Closing-keyword keys (Fixes, Closes, Resolves, etc.)
     candidates.update(k.upper() for k in _CLOSING_KEYWORD_RE.findall(body))
 
     return sorted(candidates)
@@ -106,14 +106,70 @@ def _fetch_jira_project_keys(jira_auth: str) -> set[str]:
         return set()
 
 
-def extract_jira_keys(pr_title: str, pr_body: str, jira_auth: str) -> list[str]:
+def _fetch_commit_messages(
+    owner_repo: str, pr_number: int, gh_token: str,
+) -> list[str]:
+    """
+    Fetch all commit messages for a PR via the GitHub REST API.
+
+    Returns a list of commit message strings (subject + body).
+    Paginates automatically (up to 250 commits per PR).
+    """
+    messages: list[str] = []
+    page = 1
+    per_page = 100
+
+    while True:
+        url = (f"https://api.github.com/repos/{owner_repo}"
+               f"/pulls/{pr_number}/commits"
+               f"?per_page={per_page}&page={page}")
+
+        req = Request(url)
+        req.add_header("Accept", "application/vnd.github+json")
+        req.add_header("Authorization", f"Bearer {gh_token}")
+
+        try:
+            with urlopen(req) as resp:
+                commits = json.loads(resp.read().decode())
+        except (HTTPError, URLError) as exc:
+            print(f"Warning: failed to fetch PR commits (page {page}): {exc}")
+            break
+
+        if not commits:
+            break
+
+        for commit in commits:
+            msg = commit.get("commit", {}).get("message", "")
+            if msg:
+                messages.append(msg)
+
+        if len(commits) < per_page:
+            break
+        page += 1
+
+    print(f"Fetched {len(messages)} commit message(s) from {owner_repo}#{pr_number}")
+    return messages
+
+
+def extract_jira_keys(
+    pr_title: str,
+    pr_body: str,
+    jira_auth: str,
+    owner_repo: str = "",
+    pr_number: int = 0,
+    gh_token: str = "",
+) -> list[str]:
     """
     Replicate the extract_jira_keys.yml logic in pure Python.
 
-    1. Extract candidate JIRA keys from the PR body (title is ignored).
+    1. Extract candidate JIRA keys from the PR body and commit messages.
     2. Accept keys whose project prefix is in the hard-coded set.
     3. For remaining keys, query the Jira API and accept valid prefixes.
     4. Return a sorted, deduplicated list (or ["__NO_KEYS_FOUND__"]).
+
+    When owner_repo, pr_number, and gh_token are provided the function
+    also fetches the PR's commit messages from the GitHub API and scans
+    them for closing-keyword patterns (Fixes, Closes, Resolves, etc.).
     """
     print(f"PR body: {pr_body}")
 
@@ -123,8 +179,22 @@ def extract_jira_keys(pr_title: str, pr_body: str, jira_auth: str) -> list[str]:
 
     candidates = _extract_candidate_keys(pr_body)
 
+    # Also scan commit messages for closing-keyword Jira keys (PM-279).
+    if owner_repo and pr_number and gh_token:
+        commit_messages = _fetch_commit_messages(owner_repo, pr_number, gh_token)
+        for msg in commit_messages:
+            commit_keys = _extract_candidate_keys(msg)
+            if commit_keys:
+                print(f"  Found key(s) in commit message: {commit_keys}")
+                candidates.extend(commit_keys)
+        # Re-deduplicate after merging body + commit keys.
+        candidates = sorted(set(candidates))
+    else:
+        print("Skipping commit-message scan "
+              "(owner_repo/pr_number/gh_token not provided)")
+
     if not candidates:
-        print("No Jira-like keys found in PR body")
+        print("No Jira-like keys found in PR body or commit messages")
         return ["__NO_KEYS_FOUND__"]
 
     print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")

--- a/scripts/jira_sync_modules.py
+++ b/scripts/jira_sync_modules.py
@@ -106,16 +106,16 @@ def _fetch_jira_project_keys(jira_auth: str) -> set[str]:
         return set()
 
 
-def _fetch_commit_messages(
+def _fetch_commits(
     owner_repo: str, pr_number: int, gh_token: str,
-) -> list[str]:
+) -> list[tuple[str, str]]:
     """
-    Fetch all commit messages for a PR via the GitHub REST API.
+    Fetch all commits for a PR via the GitHub REST API.
 
-    Returns a list of commit message strings (subject + body).
+    Returns a list of (short_sha, message) tuples.
     Paginates automatically (up to 250 commits per PR).
     """
-    messages: list[str] = []
+    results: list[tuple[str, str]] = []
     page = 1
     per_page = 100
 
@@ -139,16 +139,17 @@ def _fetch_commit_messages(
             break
 
         for commit in commits:
+            sha = commit.get("sha", "")[:10]
             msg = commit.get("commit", {}).get("message", "")
             if msg:
-                messages.append(msg)
+                results.append((sha, msg))
 
         if len(commits) < per_page:
             break
         page += 1
 
-    print(f"Fetched {len(messages)} commit message(s) from {owner_repo}#{pr_number}")
-    return messages
+    print(f"Fetched {len(results)} commit(s) from {owner_repo}#{pr_number}")
+    return results
 
 
 def extract_jira_keys(
@@ -179,14 +180,19 @@ def extract_jira_keys(
 
     candidates = _extract_candidate_keys(pr_body)
 
+    # Track where each key was found for logging.
+    key_origins: dict[str, list[str]] = {}
+    for key in candidates:
+        key_origins.setdefault(key, []).append("PR body")
+
     # Also scan commit messages for closing-keyword Jira keys (PM-279).
     if owner_repo and pr_number and gh_token:
-        commit_messages = _fetch_commit_messages(owner_repo, pr_number, gh_token)
-        for msg in commit_messages:
+        commits = _fetch_commits(owner_repo, pr_number, gh_token)
+        for sha, msg in commits:
             commit_keys = _extract_candidate_keys(msg)
-            if commit_keys:
-                print(f"  Found key(s) in commit message: {commit_keys}")
-                candidates.extend(commit_keys)
+            for key in commit_keys:
+                key_origins.setdefault(key, []).append(f"commit {sha}")
+            candidates.extend(commit_keys)
         # Re-deduplicate after merging body + commit keys.
         candidates = sorted(set(candidates))
     else:
@@ -200,7 +206,8 @@ def extract_jira_keys(
     print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
     print("Candidate keys:")
     for key in candidates:
-        print(f"  {key}")
+        origins = ", ".join(key_origins.get(key, ["unknown"]))
+        print(f"  {key}  (found in: {origins})")
     print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
 
     accepted: list[str] = []


### PR DESCRIPTION
Refs: PM-279

## Summary

Extend the Jira sync automation to also scan **commit messages** (not just the PR body) for closing-keyword patterns 

## Problem

Currently `extract_jira_keys()` only scans the PR body for `Fixes/Closes/Resolves JIRA-KEY` patterns. If a developer puts the Jira reference in their commit message but not in the PR description, the automation misses it and the Jira issue is never linked or transitioned.

## Changes

### `scripts/jira_sync_modules.py`
- **New function `_fetch_commit_messages()`** -- fetches all commit messages for a PR via the GitHub REST API (`GET /repos/{owner}/{repo}/pulls/{number}/commits`), with automatic pagination.
- **Updated `extract_jira_keys()` signature** -- added 3 optional parameters: `owner_repo`, `pr_number`, `gh_token` (backward compatible, defaults to empty/zero).
- **Updated `extract_jira_keys()` body** -- after scanning the PR body, also scans each commit message using the same `_extract_candidate_keys()` function and merges + deduplicates the results.
- **Renamed `_extract_candidate_keys()` parameter** from `pr_body` to `text` and updated docstring to reflect its broader use.

### `scripts/jira_sync_logic.py`
- Updated all 5 orchestrator call sites (`manage_labeled_gh_event`, `manage_review_gh_event`, `manage_closed_gh_event`, `manage_opened_gh_event`, `manage_unlabeled_gh_event`) to pass `owner_repo`, `pr_number`, and `gh_token` to `extract_jira_keys()`.

### No workflow YAML changes needed
`GITHUB_TOKEN`, `PR_NUMBER`, and `OWNER_REPO` are already available as environment variables in `main_pr_events_jira_sync.yml`.

## Design decisions
- **Backward compatible** -- the 3 new params default to empty/zero; if not passed, commit scanning is skipped and behavior is unchanged.
- **Graceful degradation** -- if the GitHub API call fails, a warning is logged and the function continues with body-only keys.
- **Same regex pipeline** -- commit messages are scanned with the exact same `_CLOSING_KEYWORD_RE` regex and `_extract_candidate_keys()` function as the PR body, ensuring consistent behavior.
- **Deduplication** -- keys found in both PR body and commit messages are merged and deduplicated before validation.
