### PR TITLE
feat(PM-279): scan PR commit messages for Jira keys

### DIFF
--- a/scripts/jira_sync_logic.py
+++ b/scripts/jira_sync_logic.py
@@ -76,7 +76,10 @@ def manage_labeled_gh_event(
     print("=" * 60)
     print(" Step 1 / extract_jira_keys")
     print("=" * 60)
-    keys = extract_jira_keys(pr_title, pr_body, jira_auth)
+    keys = extract_jira_keys(pr_title, pr_body, jira_auth,
+                             owner_repo=owner_repo,
+                             pr_number=pr_number,
+                             gh_token=gh_token)
     jira_keys_json = json.dumps(keys)
     print(f"jira-keys-json={jira_keys_json}")
 
@@ -249,7 +252,10 @@ def manage_review_gh_event(
     print("\n" + "=" * 60)
     print(" Step 1 / extract_jira_keys")
     print("=" * 60)
-    keys = extract_jira_keys(pr_title, pr_body, jira_auth)
+    keys = extract_jira_keys(pr_title, pr_body, jira_auth,
+                             owner_repo=owner_repo,
+                             pr_number=pr_number,
+                             gh_token=gh_token)
     jira_keys_json = json.dumps(keys)
     print(f"jira-keys-json={jira_keys_json}")
 
@@ -366,7 +372,10 @@ def manage_closed_gh_event(
     print("\n" + "=" * 60)
     print(" Step 1 / extract_jira_keys")
     print("=" * 60)
-    keys = extract_jira_keys(pr_title, pr_body, jira_auth)
+    keys = extract_jira_keys(pr_title, pr_body, jira_auth,
+                             owner_repo=owner_repo,
+                             pr_number=pr_number,
+                             gh_token=gh_token)
     jira_keys_json = json.dumps(keys)
     print(f"jira-keys-json={jira_keys_json}")
 
@@ -506,7 +515,10 @@ def manage_opened_gh_event(
     print("\n" + "=" * 60)
     print(" Step 1 / extract_jira_keys")
     print("=" * 60)
-    keys = extract_jira_keys(pr_title, pr_body, jira_auth)
+    keys = extract_jira_keys(pr_title, pr_body, jira_auth,
+                             owner_repo=owner_repo,
+                             pr_number=pr_number,
+                             gh_token=gh_token)
     jira_keys_json = json.dumps(keys)
     print(f"jira-keys-json={jira_keys_json}")
 
@@ -625,7 +637,10 @@ def manage_unlabeled_gh_event(
     print("\n" + "=" * 60)
     print(" Step 1 / extract_jira_keys")
     print("=" * 60)
-    keys = extract_jira_keys(pr_title, pr_body, jira_auth)
+    keys = extract_jira_keys(pr_title, pr_body, jira_auth,
+                             owner_repo=owner_repo,
+                             pr_number=pr_number,
+                             gh_token=gh_token)
     jira_keys_json = json.dumps(keys)
     print(f"jira-keys-json={jira_keys_json}")
 

--- a/scripts/jira_sync_modules.py
+++ b/scripts/jira_sync_modules.py
@@ -65,9 +65,9 @@ def _sanitize(text: str) -> str:
     return text.replace('\r', '').replace('`', ' ')
 
 
-def _extract_candidate_keys(pr_body: str) -> list[str]:
+def _extract_candidate_keys(text: str) -> list[str]:
     """
-    Extract candidate Jira keys from the PR body.
+    Extract candidate Jira keys from arbitrary text (PR body, commit message).
 
     Only keys preceded by a closing keyword (Fixes, Closes, Resolves, etc.)
     are accepted. Bare key mentions are ignored.
@@ -75,9 +75,9 @@ def _extract_candidate_keys(pr_body: str) -> list[str]:
     """
     candidates: set[str] = set()
 
-    body = _sanitize(pr_body)
+    body = _sanitize(text)
 
-    # Closing-keyword keys from body (Fixes, Closes, Resolves, etc.)
+    # Closing-keyword keys (Fixes, Closes, Resolves, etc.)
     candidates.update(k.upper() for k in _CLOSING_KEYWORD_RE.findall(body))
 
     return sorted(candidates)
@@ -106,16 +106,72 @@ def _fetch_jira_project_keys(jira_auth: str) -> set[str]:
         return set()
 
 
-def extract_jira_keys(pr_title: str, pr_body: str, jira_auth: str) -> list[str]:
+def _fetch_commits(
+    owner_repo: str, pr_number: int, gh_token: str,
+) -> list[tuple[str, str]]:
+    """
+    Fetch all commits for a PR via the GitHub REST API.
+
+    Returns a list of (short_sha, message) tuples.
+    Paginates automatically (up to 250 commits per PR).
+    """
+    results: list[tuple[str, str]] = []
+    page = 1
+    per_page = 100
+
+    while True:
+        url = (f"https://api.github.com/repos/{owner_repo}"
+               f"/pulls/{pr_number}/commits"
+               f"?per_page={per_page}&page={page}")
+
+        req = Request(url)
+        req.add_header("Accept", "application/vnd.github+json")
+        req.add_header("Authorization", f"Bearer {gh_token}")
+
+        try:
+            with urlopen(req) as resp:
+                commits = json.loads(resp.read().decode())
+        except (HTTPError, URLError) as exc:
+            print(f"Warning: failed to fetch PR commits (page {page}): {exc}")
+            break
+
+        if not commits:
+            break
+
+        for commit in commits:
+            sha = commit.get("sha", "")[:10]
+            msg = commit.get("commit", {}).get("message", "")
+            if msg:
+                results.append((sha, msg))
+
+        if len(commits) < per_page:
+            break
+        page += 1
+
+    print(f"Fetched {len(results)} commit(s) from {owner_repo}#{pr_number}")
+    return results
+
+
+def extract_jira_keys(
+    pr_title: str,
+    pr_body: str,
+    jira_auth: str,
+    owner_repo: str = "",
+    pr_number: int = 0,
+    gh_token: str = "",
+) -> list[str]:
     """
     Replicate the extract_jira_keys.yml logic in pure Python.
 
-    1. Extract candidate JIRA keys from the PR body (title is ignored).
+    1. Extract candidate JIRA keys from the PR body and commit messages.
     2. Accept keys whose project prefix is in the hard-coded set.
     3. For remaining keys, query the Jira API and accept valid prefixes.
     4. Return a sorted, deduplicated list (or ["__NO_KEYS_FOUND__"]).
+
+    When owner_repo, pr_number, and gh_token are provided the function
+    also fetches the PR's commit messages from the GitHub API and scans
+    them for closing-keyword patterns (Fixes, Closes, Resolves, etc.).
     """
-    print(f"PR title: {pr_title}")
     print(f"PR body: {pr_body}")
 
     if not jira_auth:
@@ -124,14 +180,34 @@ def extract_jira_keys(pr_title: str, pr_body: str, jira_auth: str) -> list[str]:
 
     candidates = _extract_candidate_keys(pr_body)
 
+    # Track where each key was found for logging.
+    key_origins: dict[str, list[str]] = {}
+    for key in candidates:
+        key_origins.setdefault(key, []).append("PR body")
+
+    # Also scan commit messages for closing-keyword Jira keys (PM-279).
+    if owner_repo and pr_number and gh_token:
+        commits = _fetch_commits(owner_repo, pr_number, gh_token)
+        for sha, msg in commits:
+            commit_keys = _extract_candidate_keys(msg)
+            for key in commit_keys:
+                key_origins.setdefault(key, []).append(f"commit {sha}")
+            candidates.extend(commit_keys)
+        # Re-deduplicate after merging body + commit keys.
+        candidates = sorted(set(candidates))
+    else:
+        print("Skipping commit-message scan "
+              "(owner_repo/pr_number/gh_token not provided)")
+
     if not candidates:
-        print("No Jira-like keys found in PR body")
+        print("No Jira-like keys found in PR body or commit messages")
         return ["__NO_KEYS_FOUND__"]
 
     print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
     print("Candidate keys:")
     for key in candidates:
-        print(f"  {key}")
+        origins = ", ".join(key_origins.get(key, ["unknown"]))
+        print(f"  {key}  (found in: {origins})")
     print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
 
     accepted: list[str] = []
@@ -1077,7 +1153,7 @@ def jira_status_transition(
 
     print(f"Summary: ok={ok} skipped={skipped} failed={failed}")
     if failed > 0:
-        print(f"WARNING: {failed} transition(s) failed. Continuing.")
+        print(f"WARNING: {failed} comment(s) failed. Continuing.")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
﻿## Summary

Extend the Jira sync automation to scan PR commit messages (in addition to the PR body) for closing-keyword Jira keys . Previously, only the PR body was scanned for Jira issue references.

Fixes: PM-279

## Changes

### `scripts/jira_sync_modules.py`

- **Renamed `_extract_candidate_keys` parameter** from `pr_body` to `text` to reflect that it now processes arbitrary text (PR body or commit messages), not just PR bodies.
- **Added `_fetch_commits` function** — fetches all commits for a PR via the GitHub REST API with pagination support (up to 250 commits). Returns a list of `(short_sha, message)` tuples.
- **Updated `extract_jira_keys` signature** — added three new optional parameters: `owner_repo`, `pr_number`, and `gh_token`. When all three are provided, the function fetches the PR's commit messages and scans them for closing-keyword Jira keys.
- **Added `key_origins` tracking** — logs where each Jira key was found (PR body vs. specific commit SHA) for better debugging and traceability.
- **Updated log messages** to reflect that keys can now come from both PR body and commit messages.

### `scripts/jira_sync_logic.py`

- **Updated all five orchestrator functions** (`manage_labeled_gh_event`, `manage_review_gh_event`, `manage_closed_gh_event`, `manage_opened_gh_event`, `manage_unlabeled_gh_event`) to pass `owner_repo`, `pr_number`, and `gh_token` to `extract_jira_keys`, enabling commit message scanning in all PR event handlers.
