### PR TITLE
jira_sync: stop syncing backport/* and promoted-to-* labels from Jira to PRs

### DIFF
--- a/scripts/jira_sync_modules.py
+++ b/scripts/jira_sync_modules.py
@@ -777,9 +777,14 @@ def _compute_labels(labels_csv: str, details_csv: str, new_priority_label: str) 
             seen.add(s)
             labels.append(s)
 
-    # 2) Remove P0..P4 from base list
+    # 2) Remove P0..P4 and workflow-managed labels from base list.
+    #    backport/* and promoted-to-* labels are managed by the backport
+    #    automation and must never be synced from Jira to PRs -- doing so
+    #    can break the backport chain (e.g. re-adding a backport/X.Y label
+    #    for a version that was already completed).
     priority_names = {"P0", "P1", "P2", "P3", "P4"}
-    labels = [lb for lb in labels if lb not in priority_names]
+    _WORKFLOW_MANAGED_RE = re.compile(r"^(backport/|promoted-to-)")
+    labels = [lb for lb in labels if lb not in priority_names and not _WORKFLOW_MANAGED_RE.match(lb)]
 
     # 3) Parse details CSV for priority + scylla_components
     best_rank = None


### PR DESCRIPTION
These labels are managed exclusively by the backport automation workflow. When Jira label sync blindly copies them onto newly-opened backport PRs, it can break the backport chain: the chain logic sees an extra backport/X.Y label for a version that was already completed and picks it as the next target instead of the correct one.

Root cause observed on scylladb/scylla-pkg#6111: Jira issue RELENG-454 carried backport/2026.1 and promoted-to-master labels (from the parent PR). When the 2026.1 backport PR was opened, the Jira sync workflow re-applied those labels, causing process_chain_backport() to attempt backporting to 2026.1 again (commit already existed) and silently skip the 2025.4 backport entirely.

Filter out any label matching backport/* or promoted-to-* in _compute_labels() so they are never applied by the Jira sync workflow.