### PR TITLE
backport-with-jira: add retry logic for transient GitHub API errors

### DIFF
--- a/.github/tests/test_gh_retry.sh
+++ b/.github/tests/test_gh_retry.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+# Test suite for the gh_retry() function used in backport-with-jira.yaml
+# Run with: bash .github/tests/test_gh_retry.sh
+set -uo pipefail
+
+PASS=0
+FAIL=0
+TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT
+
+# The gh_retry function under test (with 0 sleep for fast tests)
+gh_retry() {
+  local max_attempts=3
+  local delay=0
+  local attempt=1
+  local output
+  local status
+  while [ $attempt -le $max_attempts ]; do
+    output=$("$GH_MOCK" "$@" 2>&1)
+    status=$?
+    if [ $status -eq 0 ]; then
+      echo "$output"
+      return 0
+    fi
+    if echo "$output" | grep -qi "error connecting\|connection refused\|timeout\|ETIMEDOUT\|network\|502\|503"; then
+      echo "::warning::gh command failed (attempt ${attempt}/${max_attempts}): $output" >&2
+      if [ $attempt -lt $max_attempts ]; then
+        sleep $delay
+        delay=$((delay * 2))
+      fi
+    else
+      echo "$output"
+      return $status
+    fi
+    attempt=$((attempt + 1))
+  done
+  echo "::error::gh command failed after ${max_attempts} attempts: $output" >&2
+  echo "$output"
+  return $status
+}
+
+assert_eq() {
+  local test_name="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "  PASS: $test_name"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $test_name (expected='$expected', actual='$actual')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# --- Test 1: Successful command on first attempt ---
+echo "Test 1: Success on first attempt"
+cat > "$TMPDIR/mock_gh" << 'EOF'
+#!/bin/bash
+echo "success output"
+exit 0
+EOF
+chmod +x "$TMPDIR/mock_gh"
+GH_MOCK="$TMPDIR/mock_gh"
+output=$(gh_retry api /repos 2>/dev/null)
+assert_eq "returns output" "success output" "$output"
+
+# --- Test 2: Non-transient error fails immediately ---
+echo "Test 2: Non-transient error fails immediately"
+cat > "$TMPDIR/mock_gh" << 'EOF'
+#!/bin/bash
+echo "permission denied"
+exit 1
+EOF
+chmod +x "$TMPDIR/mock_gh"
+GH_MOCK="$TMPDIR/mock_gh"
+output=$(gh_retry api /repos 2>/dev/null)
+assert_eq "returns error output" "permission denied" "$output"
+
+# --- Test 3: Transient error retries then succeeds ---
+echo "Test 3: Transient error retries then succeeds"
+COUNTER="$TMPDIR/counter3"
+echo "0" > "$COUNTER"
+cat > "$TMPDIR/mock_gh" << EOF
+#!/bin/bash
+count=\$(cat "$COUNTER")
+count=\$((count + 1))
+echo "\$count" > "$COUNTER"
+if [ \$count -lt 3 ]; then
+  echo "error connecting to api.github.com"
+  exit 1
+fi
+echo "success after retry"
+exit 0
+EOF
+chmod +x "$TMPDIR/mock_gh"
+GH_MOCK="$TMPDIR/mock_gh"
+output=$(gh_retry api /repos 2>/dev/null)
+status=$?
+assert_eq "succeeds after retries" "success after retry" "$output"
+assert_eq "exit code is 0" "0" "$status"
+assert_eq "called 3 times" "3" "$(cat $COUNTER)"
+
+# --- Test 4: Transient error exhausts all retries ---
+echo "Test 4: Transient error exhausts retries"
+cat > "$TMPDIR/mock_gh" << 'EOF'
+#!/bin/bash
+echo "connection refused"
+exit 1
+EOF
+chmod +x "$TMPDIR/mock_gh"
+GH_MOCK="$TMPDIR/mock_gh"
+output=$(gh_retry api /repos 2>/dev/null)
+status=$?
+assert_eq "returns last error" "connection refused" "$output"
+assert_eq "exit code is non-zero" "1" "$status"
+
+# --- Test 5: 502 error is treated as transient ---
+echo "Test 5: 502 error is transient"
+COUNTER="$TMPDIR/counter5"
+echo "0" > "$COUNTER"
+cat > "$TMPDIR/mock_gh" << EOF
+#!/bin/bash
+count=\$(cat "$COUNTER")
+count=\$((count + 1))
+echo "\$count" > "$COUNTER"
+if [ \$count -lt 2 ]; then
+  echo "HTTP 502 Bad Gateway"
+  exit 1
+fi
+echo "ok"
+exit 0
+EOF
+chmod +x "$TMPDIR/mock_gh"
+GH_MOCK="$TMPDIR/mock_gh"
+output=$(gh_retry api /repos 2>/dev/null)
+assert_eq "recovers from 502" "ok" "$output"
+
+# --- Test 6: ETIMEDOUT is treated as transient ---
+echo "Test 6: ETIMEDOUT is transient"
+COUNTER="$TMPDIR/counter6"
+echo "0" > "$COUNTER"
+cat > "$TMPDIR/mock_gh" << EOF
+#!/bin/bash
+count=\$(cat "$COUNTER")
+count=\$((count + 1))
+echo "\$count" > "$COUNTER"
+if [ \$count -lt 2 ]; then
+  echo "dial tcp: ETIMEDOUT"
+  exit 1
+fi
+echo "recovered"
+exit 0
+EOF
+chmod +x "$TMPDIR/mock_gh"
+GH_MOCK="$TMPDIR/mock_gh"
+output=$(gh_retry api /repos 2>/dev/null)
+assert_eq "recovers from ETIMEDOUT" "recovered" "$output"
+
+# --- Test 7: 503 error is treated as transient ---
+echo "Test 7: 503 error is transient"
+COUNTER="$TMPDIR/counter7"
+echo "0" > "$COUNTER"
+cat > "$TMPDIR/mock_gh" << EOF
+#!/bin/bash
+count=\$(cat "$COUNTER")
+count=\$((count + 1))
+echo "\$count" > "$COUNTER"
+if [ \$count -lt 2 ]; then
+  echo "HTTP 503 Service Unavailable"
+  exit 1
+fi
+echo "back online"
+exit 0
+EOF
+chmod +x "$TMPDIR/mock_gh"
+GH_MOCK="$TMPDIR/mock_gh"
+output=$(gh_retry api /repos 2>/dev/null)
+assert_eq "recovers from 503" "back online" "$output"
+
+# --- Summary ---
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ $FAIL -gt 0 ]; then
+  exit 1
+fi

--- a/.github/workflows/backport-with-jira.yaml
+++ b/.github/workflows/backport-with-jira.yaml
@@ -190,8 +190,39 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.gh_token }}
         run: |
+          # Retry wrapper for gh CLI commands to handle transient GitHub API failures
+          gh_retry() {
+            local max_attempts=3
+            local delay=10
+            local attempt=1
+            local output
+            local status
+            while [ $attempt -le $max_attempts ]; do
+              output=$(gh "$@" 2>&1)
+              status=$?
+              if [ $status -eq 0 ]; then
+                echo "$output"
+                return 0
+              fi
+              if echo "$output" | grep -qi "error connecting\|connection refused\|timeout\|ETIMEDOUT\|network\|502\|503"; then
+                echo "::warning::gh command failed (attempt ${attempt}/${max_attempts}): $output" >&2
+                if [ $attempt -lt $max_attempts ]; then
+                  sleep $delay
+                  delay=$((delay * 2))
+                fi
+              else
+                echo "$output"
+                return $status
+              fi
+              attempt=$((attempt + 1))
+            done
+            echo "::error::gh command failed after ${max_attempts} attempts: $output" >&2
+            echo "$output"
+            return $status
+          }
+
           # Get all running workflows for this PR
-          runs=$(gh api \
+          runs=$(gh_retry api \
             -H "Accept: application/vnd.github+json" \
             "/repos/${{ github.repository }}/actions/runs?status=in_progress&event=pull_request_target" \
             --jq ".workflow_runs[] | select(.name == \"${{ github.workflow }}\") | .id" | sort -n)
@@ -276,10 +307,45 @@ jobs:
           DOCKERHUB_USERNAME: ${{ secrets.dockerhub_username }}
           DOCKERHUB_TOKEN: ${{ secrets.dockerhub_token }}
         run: |
+          # Retry wrapper for gh CLI commands to handle transient GitHub API failures
+          gh_retry() {
+            local max_attempts=3
+            local delay=10
+            local attempt=1
+            local output
+            local status
+            while [ $attempt -le $max_attempts ]; do
+              output=$(gh "$@" 2>&1)
+              status=$?
+              if [ $status -eq 0 ]; then
+                echo "$output"
+                return 0
+              fi
+              if echo "$output" | grep -qi "error connecting\|connection refused\|timeout\|ETIMEDOUT\|network\|502\|503"; then
+                echo "::warning::gh command failed (attempt ${attempt}/${max_attempts}): $output" >&2
+                if [ $attempt -lt $max_attempts ]; then
+                  sleep $delay
+                  delay=$((delay * 2))
+                fi
+              else
+                # Non-transient error, fail immediately
+                echo "$output"
+                return $status
+              fi
+              attempt=$((attempt + 1))
+            done
+            echo "::error::gh command failed after ${max_attempts} attempts: $output" >&2
+            echo "$output"
+            return $status
+          }
+
           # Find draft PRs with 'conflicts' label authored by scylladbbot
-          CONFLICTED_PRS=$(gh pr list --repo "${{ github.repository }}" \
+          CONFLICTED_PRS=$(gh_retry pr list --repo "${{ github.repository }}" \
             --author scylladbbot --label conflicts --draft --json number,headRefName,baseRefName,headRepositoryOwner \
-            --jq '.[] | "\(.number) \(.headRefName) \(.baseRefName) \(.headRepositoryOwner.login)"')
+            --jq '.[] | "\(.number) \(.headRefName) \(.baseRefName) \(.headRepositoryOwner.login)"') || {
+            echo "::warning::Failed to list conflicted PRs due to GitHub API issues, skipping."
+            exit 0
+          }
 
           if [ -z "$CONFLICTED_PRS" ]; then
             echo "No conflicted backport PRs found, skipping."
@@ -297,7 +363,7 @@ jobs:
             echo "::group::Resolving conflicts on PR #${PR_NUMBER} (${FORK_OWNER}:${HEAD_BRANCH} -> ${BASE_BRANCH})"
 
             # Dedup: skip if AI already commented on this PR (another workflow run got there first)
-            EXISTING_COMMENT=$(gh pr view "${PR_NUMBER}" --repo "${{ github.repository }}" \
+            EXISTING_COMMENT=$(gh_retry pr view "${PR_NUMBER}" --repo "${{ github.repository }}" \
               --json comments --jq '.comments[] | select(.body | contains("Conflicts in this backport were automatically resolved by AI")) | .id' | head -1)
             if [ -n "$EXISTING_COMMENT" ]; then
               echo "PR #${PR_NUMBER} already has an AI resolution comment, skipping."
@@ -347,10 +413,10 @@ jobs:
               # Push the resolved branch back to the fork
               git push fork "${HEAD_BRANCH}" --force-with-lease
               # Mark PR as ready and remove conflicts label
-              gh pr ready "${PR_NUMBER}" --repo "${{ github.repository }}"
-              gh pr edit "${PR_NUMBER}" --repo "${{ github.repository }}" --remove-label conflicts
+              gh_retry pr ready "${PR_NUMBER}" --repo "${{ github.repository }}"
+              gh_retry pr edit "${PR_NUMBER}" --repo "${{ github.repository }}" --remove-label conflicts
               # Add a comment indicating AI resolution
-              gh pr comment "${PR_NUMBER}" --repo "${{ github.repository }}" \
+              gh_retry pr comment "${PR_NUMBER}" --repo "${{ github.repository }}" \
                 --body $':robot: Conflicts in this backport were automatically resolved by AI (OpenCode resolve-conflicts skill).\n\nPlease review the changes carefully to ensure correctness.'
             else
               echo "::error::Failed to resolve conflicts on PR #${PR_NUMBER} (exit code: ${RESOLVE_STATUS})"


### PR DESCRIPTION
## Summary
- Add `gh_retry()` wrapper function that retries `gh` CLI commands up to 3 times with exponential backoff on transient GitHub API connectivity errors
- Wrap all 6 `gh` CLI calls in the backport-with-jira workflow with retry logic
- Gracefully handle persistent `gh pr list` failures with a warning instead of failing CI

Fixes: RELENG-551