### PR TITLE
fix: filter Closes-referenced PRs by base branch in promoted-to labeling

### DIFF
--- a/.github/scripts/auto-backport-jira.py
+++ b/.github/scripts/auto-backport-jira.py
@@ -1977,12 +1977,20 @@ def process_branch_push(repo, commits_range: str, branch_name: str, repo_name: s
         # Also find PRs referenced via "Closes #X" in commit messages.
         # This handles single-commit PRs that are closed (not merged) with a commit event
         # (e.g., in scylladb/scylladb), which commit.get_pulls() does not return.
+        # IMPORTANT: Only include PRs whose base branch matches the branch being pushed to,
+        # because promoter commits may contain Closes references to PRs from other branches
+        # (e.g., a commit promoted to branch-2025.1 may reference backport PRs for 2026.1).
         for match in re.finditer(r'Closes\s+(?:[\w-]+/[\w-]+)?#(\d+)', commit.commit.message):
             pr_number = int(match.group(1))
             if pr_number not in seen_in_commit and pr_number not in processed_prs:
                 try:
                     closed_pr = repo.get_pull(pr_number)
                     if closed_pr.state == 'closed':
+                        # Only process PRs that target this branch to avoid adding
+                        # wrong promoted-to labels to PRs from other branches
+                        if closed_pr.base.ref != branch_name:
+                            logging.info(f"Skipping PR #{pr_number} from 'Closes' reference: targets {closed_pr.base.ref}, not {branch_name}")
+                            continue
                         prs_for_commit.append(closed_pr)
                         logging.info(f"Found closed-with-commit PR #{pr_number} via 'Closes' reference")
                 except Exception as e:

--- a/.github/scripts/search_commits.py
+++ b/.github/scripts/search_commits.py
@@ -75,11 +75,15 @@ def main():
         prs = response.json().get("items", [])
         # Fallback: if the commit message has "Closes" references, include those PRs too
         # This handles PRs closed by pushing a rebased commit directly (different SHA than the PR's head)
+        # IMPORTANT: Only include PRs whose base branch matches the branch being pushed to,
+        # because promoter commits may contain Closes references to PRs from other branches.
         found_pr_numbers = {pr["number"] for pr in prs}
         close_refs = re.findall(
             rf'Closes\s+(?:{re.escape(args.repository)}#|#)(\d+)',
             commit.commit.message
         )
+        # Extract the short branch name from the ref for comparison
+        target_branch = args.ref.replace('refs/heads/', '') if args.ref.startswith('refs/heads/') else args.ref
         for ref in close_refs:
             pr_num = int(ref)
             if pr_num not in found_pr_numbers and pr_num not in processed_prs:
@@ -88,6 +92,12 @@ def main():
                 if pr_response.ok:
                     pr_data = pr_response.json()
                     if pr_data.get("state") == "closed":
+                        # Only process PRs that target this branch to avoid adding
+                        # wrong promoted-to labels to PRs from other branches
+                        pr_base_branch = pr_data.get("base", {}).get("ref", "")
+                        if pr_base_branch != target_branch:
+                            print(f"Skipping PR #{pr_num} from 'Closes' reference: targets {pr_base_branch}, not {target_branch}")
+                            continue
                         prs.append(pr_data)
         for pr in prs:
             match = re.findall(r'Parent PR: #(\d+)', pr["body"])


### PR DESCRIPTION
## Summary

When a promoter commit contains `Closes #X` references to PRs from other branches (e.g., a commit promoted to `branch-2025.1` references backport PRs for 2026.2, 2026.1, 2025.4), both `search_commits.py` and `process_branch_push()` in `auto-backport-jira.py` incorrectly processed those PRs and added the wrong `promoted-to-branch-X.Y` label to all of them.

**Root cause:** The `Closes` fallback logic fetched any closed PR referenced in a promoted commit's message without verifying that the PR actually targeted the branch being pushed to.

**Fix:** Before processing a PR found via `Closes` reference, check that its base branch matches the branch being pushed to. PRs targeting other branches are now skipped with a log message.

**Example of the bug:** Push to `branch-2025.1` with a commit containing:
```
Closes scylladb/scylladb#29747  (targets branch-2026.2)
Closes scylladb/scylladb#29802  (targets branch-2026.1)
Closes scylladb/scylladb#29812  (targets branch-2025.4)
```
All three PRs incorrectly received `promoted-to-branch-2025.1`.

Fixes: RELENG-552