### PR TITLE
fix: only add PR-created Jira comment on 'opened' event (PM-314)

### DIFF
--- a/scripts/jira_sync_logic.py
+++ b/scripts/jira_sync_logic.py
@@ -560,18 +560,22 @@ def manage_opened_gh_event(
     print("=" * 60)
     jira_status_transition(csv_content, "In Progress", "111", jira_auth)
 
-    # --- Step 5: add comment to Jira ---
-    print("\n" + "=" * 60)
-    print(" Step 5 / add_comment_to_jira (new PR created)")
-    print("=" * 60)
-    pr_url = f"https://github.com/{owner_repo}/pull/{pr_number}"
-    add_comment_to_jira(
-        jira_keys_json,
-        "A new linked PR was created: ",
-        jira_auth,
-        link_text=pr_title,
-        link_url=pr_url,
-    )
+    # --- Step 5: add comment to Jira (only on PR creation, not edits) ---
+    caller_action = os.environ.get("CALLER_ACTION", "")
+    if caller_action == "opened":
+        print("\n" + "=" * 60)
+        print(" Step 5 / add_comment_to_jira (new PR created)")
+        print("=" * 60)
+        pr_url = f"https://github.com/{owner_repo}/pull/{pr_number}"
+        add_comment_to_jira(
+            jira_keys_json,
+            "A new linked PR was created: ",
+            jira_auth,
+            link_text=pr_title,
+            link_url=pr_url,
+        )
+    else:
+        print(f"\n Skipping Step 5 (add PR-created comment): caller_action={caller_action!r}, not 'opened'")
 
     print("\n" + "=" * 60)
     print(" manage_opened_gh_event completed successfully")


### PR DESCRIPTION
The PM-313 comment ('A new linked PR was created') was being added on both 'opened' and 'edited' PR events, since both route to manage_opened_gh_event.

This fix guards Step 5 with a check on CALLER_ACTION so the comment is only posted when the PR is first created (opened), not when it is edited.

Unit tests were updated, and the fix was verified in staging https://github.com/scylladb/staging/actions/runs/26089909923/job/76712582102

Fixes: PM-314