### PR TITLE
Fix docstring syntax error in get_done_issue_keys (PM-315)

### DIFF
--- a/scripts/jira_sync_logic.py
+++ b/scripts/jira_sync_logic.py
@@ -22,6 +22,7 @@ from jira_sync_modules import (
     jira_status_transition,
     add_comment_to_jira,
     remove_label_from_jira_issue,
+    get_done_issue_keys,
 )
 
 # Sentinel value returned by extract_jira_keys when no keys are found.
@@ -411,26 +412,35 @@ def manage_closed_gh_event(
     )
 
     # --- Step 4: add "PR closed" comment ---
+    # Skip comment for issues already in a Done/closed state (PM-315).
     print("\n" + "=" * 60)
     print(" Step 4 / add_comment_to_jira (PR closed)")
     print("=" * 60)
-    pr_url = f"https://github.com/{owner_repo}/pull/{pr_number}"
-    if pr_merged:
-        add_comment_to_jira(
-            jira_keys_json,
-            "Closed via PR merge ",
-            jira_auth,
-            link_text=pr_title,
-            link_url=pr_url,
-        )
+    done_keys = get_done_issue_keys(csv_content)
+    commentable_keys = [k for k in keys if k not in done_keys]
+    if done_keys:
+        print(f"Skipping 'PR closed' comment for issues already in Done state: {sorted(done_keys)}")
+    if not commentable_keys:
+        print("All linked issues are already in a Done state. Skipping comment.")
     else:
-        add_comment_to_jira(
-            jira_keys_json,
-            "PR closed without merge ",
-            jira_auth,
-            link_text=pr_title,
-            link_url=pr_url,
-        )
+        commentable_keys_json = json.dumps(commentable_keys)
+        pr_url = f"https://github.com/{owner_repo}/pull/{pr_number}"
+        if pr_merged:
+            add_comment_to_jira(
+                commentable_keys_json,
+                "Closed via PR merge ",
+                jira_auth,
+                link_text=pr_title,
+                link_url=pr_url,
+            )
+        else:
+            add_comment_to_jira(
+                commentable_keys_json,
+                "PR closed without merge ",
+                jira_auth,
+                link_text=pr_title,
+                link_url=pr_url,
+            )
 
     # --- Step 5: transition to Done (merged PRs only) ---
     print("\n" + "=" * 60)

--- a/scripts/jira_sync_modules.py
+++ b/scripts/jira_sync_modules.py
@@ -1263,19 +1263,11 @@ def add_comment_to_jira(
 
 
 def get_done_issue_keys(details_csv: str) -> set[str]:
-<<<<<<< pm-315-skip-close-comment-done-issues
     """Parse the details CSV and return issue keys whose status is in a closed/done state.
 
     This is used to skip writing "PR closed" comments on issues that are
     already resolved (PM-315).
     """
-=======
-    ```Parse the details CSV and return issue keys whose status is in a closed/done state.
-
-    This is used to skip writing "PR closed" comments on issues that are
-    already resolved (PM-315).
-    ```
->>>>>>> automation-staging-branch
     done_keys: set[str] = set()
     stripped = details_csv.strip()
     if not stripped:

--- a/scripts/jira_sync_modules.py
+++ b/scripts/jira_sync_modules.py
@@ -1262,3 +1262,22 @@ def add_comment_to_jira(
         print(f"WARNING: {failed} comment(s) failed. Continuing.")
 
 
+def get_done_issue_keys(details_csv: str) -> set[str]:
+    """Parse the details CSV and return issue keys whose status is in a closed/done state.
+
+    This is used to skip writing "PR closed" comments on issues that are
+    already resolved (PM-315).
+    """
+    done_keys: set[str] = set()
+    stripped = details_csv.strip()
+    if not stripped:
+        return done_keys
+
+    reader = csv.DictReader(io.StringIO(stripped))
+    for row in reader:
+        key = (row.get("key") or "").strip()
+        status = (row.get("status") or "").strip()
+        if key and status.lower() in _CLOSED_STATES:
+            done_keys.add(key)
+
+    return done_keys


### PR DESCRIPTION
Fixes SyntaxError on line 1266 of `jira_sync_modules.py` ? the docstring for `get_done_issue_keys()` used triple backticks instead of triple double-quotes.

This was introduced in the now-closed PR #185.

Refs PM-315