### PR TITLE
Skip PR-close comment when Jira issue is already Done (PM-315)

### DIFF
--- a/scripts/jira_sync_logic.py
+++ b/scripts/jira_sync_logic.py
@@ -22,6 +22,7 @@ from jira_sync_modules import (
     jira_status_transition,
     add_comment_to_jira,
     remove_label_from_jira_issue,
+    get_done_issue_keys,
 )
 
 # Sentinel value returned by extract_jira_keys when no keys are found.
@@ -411,26 +412,35 @@ def manage_closed_gh_event(
     )
 
     # --- Step 4: add "PR closed" comment ---
+    # Skip comment for issues already in a Done/closed state (PM-315).
     print("\n" + "=" * 60)
     print(" Step 4 / add_comment_to_jira (PR closed)")
     print("=" * 60)
-    pr_url = f"https://github.com/{owner_repo}/pull/{pr_number}"
-    if pr_merged:
-        add_comment_to_jira(
-            jira_keys_json,
-            "Closed via PR merge ",
-            jira_auth,
-            link_text=pr_title,
-            link_url=pr_url,
-        )
+    done_keys = get_done_issue_keys(csv_content)
+    commentable_keys = [k for k in keys if k not in done_keys]
+    if done_keys:
+        print(f"Skipping 'PR closed' comment for issues already in Done state: {sorted(done_keys)}")
+    if not commentable_keys:
+        print("All linked issues are already in a Done state. Skipping comment.")
     else:
-        add_comment_to_jira(
-            jira_keys_json,
-            "PR closed without merge ",
-            jira_auth,
-            link_text=pr_title,
-            link_url=pr_url,
-        )
+        commentable_keys_json = json.dumps(commentable_keys)
+        pr_url = f"https://github.com/{owner_repo}/pull/{pr_number}"
+        if pr_merged:
+            add_comment_to_jira(
+                commentable_keys_json,
+                "Closed via PR merge ",
+                jira_auth,
+                link_text=pr_title,
+                link_url=pr_url,
+            )
+        else:
+            add_comment_to_jira(
+                commentable_keys_json,
+                "PR closed without merge ",
+                jira_auth,
+                link_text=pr_title,
+                link_url=pr_url,
+            )
 
     # --- Step 5: transition to Done (merged PRs only) ---
     print("\n" + "=" * 60)

--- a/scripts/jira_sync_modules.py
+++ b/scripts/jira_sync_modules.py
@@ -1262,3 +1262,22 @@ def add_comment_to_jira(
         print(f"WARNING: {failed} comment(s) failed. Continuing.")
 
 
+def get_done_issue_keys(details_csv: str) -> set[str]:
+    """Parse the details CSV and return issue keys whose status is in a closed/done state.
+
+    This is used to skip writing "PR closed" comments on issues that are
+    already resolved (PM-315).
+    """
+    done_keys: set[str] = set()
+    stripped = details_csv.strip()
+    if not stripped:
+        return done_keys
+
+    reader = csv.DictReader(io.StringIO(stripped))
+    for row in reader:
+        key = (row.get("key") or "").strip()
+        status = (row.get("status") or "").strip()
+        if key and status.lower() in _CLOSED_STATES:
+            done_keys.add(key)
+
+    return done_keys


### PR DESCRIPTION
## Summary

Fixes [PM-315](https://scylladb.atlassian.net/browse/PM-315)

When a PR is closed (merged or not), the automation posts a "PR closed" comment to all linked Jira issues. If the issue is already in a Done/closed state, this comment is unnecessary noise.

## Changes

### `scripts/jira_sync_modules.py`
- Added `get_done_issue_keys(details_csv)` helper that parses the issue details CSV and returns the set of issue keys already in a closed state (Done, Won't Fix, Duplicate).

### `scripts/jira_sync_logic.py`
- Imported `get_done_issue_keys` from `jira_sync_modules`.
- In `manage_closed_gh_event` step 4, filter out issues already in a Done state before posting the PR-closed comment. Skipped issues are logged.

## Testing

Successfully tested in `automation-staging-branch` (PR #186).

[PM-315]: https://scylladb.atlassian.net/browse/PM-315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ