### PR TITLE
fix: prevent duplicate backport PRs for the same target version

### DIFF
--- a/.github/scripts/auto-backport-jira.py
+++ b/.github/scripts/auto-backport-jira.py
@@ -1435,13 +1435,14 @@ def find_existing_backport_pr(repo, original_pr_number: int, version: str):
     Find an existing backport PR for a specific version.
     
     Checks for:
-    1. Open PRs with the backport branch pattern
-    2. Recently merged PRs (to handle race conditions)
-    3. Any PR in any state with the backport branch pattern
+    1. Open PRs with the exact backport branch pattern for this source PR
+    2. Any PR (all states) with the exact backport branch pattern for this source PR
+    3. Open PRs from ANY source PR targeting the same version (prevents duplicates
+       when both chain backport and original PR label processing race)
     
     Returns the PR object if found, None otherwise.
     """
-    # Search for PRs with the backport branch naming pattern
+    # Search for PRs with the backport branch naming pattern for this specific source PR
     branch_pattern = f"backport/{original_pr_number}/to-{version}"
     try:
         # Check open PRs first
@@ -1458,6 +1459,26 @@ def find_existing_backport_pr(repo, original_pr_number: int, version: str):
             return pull
     except Exception as e:
         logging.warning(f"Error searching for existing backport PR: {e}")
+
+    # Check for backport PRs from ANY source PR targeting the same version.
+    # This prevents duplicates when a chain backport (e.g., from PR #200) and the
+    # original PR's label processing (from PR #100) both try to create a backport
+    # to the same target version, using different branch names.
+    try:
+        target_branch = get_branch_name(repo.full_name, version)
+        pulls = repo.get_pulls(state='open', base=target_branch)
+        backport_title_prefix = f'[Backport {version}]'
+        for pull in pulls:
+            if (pull.head.ref.startswith('backport/') and
+                    pull.head.ref.endswith(f'/to-{version}') and
+                    pull.title.startswith(backport_title_prefix) and
+                    pull.user.login == 'scylladbbot'):
+                logging.info(f"Found existing open backport PR #{pull.number} from different source "
+                             f"(branch: {pull.head.ref}) for version {version}")
+                return pull
+    except Exception as e:
+        logging.warning(f"Error searching for existing backport PR by target branch: {e}")
+
     return None
 
 

--- a/.github/tests/test_label_and_pr_management.py
+++ b/.github/tests/test_label_and_pr_management.py
@@ -87,6 +87,39 @@ class TestFindExistingBackportPr:
         result = bp_module.find_existing_backport_pr(repo, 10, "2025.4")
         assert result is None
 
+    def test_found_from_different_source_pr(self, bp_module, make_pr, make_repo):
+        """Detects duplicate when another source PR already created a backport to same version."""
+        repo = make_repo()
+        # Exact-match searches return empty (different source PR number)
+        other_pr = make_pr(number=99)
+        other_pr.head = MagicMock()
+        other_pr.head.ref = "backport/20/to-2025.4"
+        other_pr.title = "[Backport 2025.4] Fix bug"
+        other_pr.user = MagicMock()
+        other_pr.user.login = "scylladbbot"
+
+        # First two get_pulls calls (exact match) return empty,
+        # third call (broad search by base branch) returns the other PR
+        repo.get_pulls.side_effect = [[], [], [other_pr]]
+
+        result = bp_module.find_existing_backport_pr(repo, 10, "2025.4")
+        assert result.number == 99
+
+    def test_broad_check_ignores_non_bot_prs(self, bp_module, make_pr, make_repo):
+        """Broad check skips PRs not created by scylladbbot."""
+        repo = make_repo()
+        other_pr = make_pr(number=99)
+        other_pr.head = MagicMock()
+        other_pr.head.ref = "backport/20/to-2025.4"
+        other_pr.title = "[Backport 2025.4] Fix bug"
+        other_pr.user = MagicMock()
+        other_pr.user.login = "someuser"
+
+        repo.get_pulls.side_effect = [[], [], [other_pr]]
+
+        result = bp_module.find_existing_backport_pr(repo, 10, "2025.4")
+        assert result is None
+
     def test_error_returns_none(self, bp_module, make_repo):
         repo = make_repo()
         repo.get_pulls.side_effect = Exception("API error")


### PR DESCRIPTION
## Summary

When a PR is backported through a chain (original → 2026.1 → 2025.4 → 2025.1), both the chain continuation and the original PR's label processing could create separate backport PRs targeting the same branch. This happened because `find_existing_backport_pr()` only searched for branches matching the exact source PR number (e.g., `backport/100/to-2025.1`), so a backport created from an intermediate PR (e.g., `backport/200/to-2025.1`) would not be detected as a duplicate.

### Fix

Added a broader duplicate detection step in `find_existing_backport_pr()`: after the exact-match checks fail, search for ANY open backport PR targeting the same version branch by querying all open PRs on the target base branch and filtering for:
- Head branch matching `backport/*/to-{version}`
- Title starting with `[Backport {version}]`
- Created by `scylladbbot`

This catches duplicates regardless of which source PR created the first backport.

### Testing

Added 2 new unit tests:
- `test_found_from_different_source_pr` - verifies detection of existing backport from a different source PR
- `test_broad_check_ignores_non_bot_prs` - verifies non-bot PRs are not falsely matched

All 343 passing tests continue to pass (7 pre-existing failures in `test_backport_orchestration.py` are unrelated `clone_from` mock issues).

Fixes: RELENG-455