### PR TITLE
PM-282: Sync milestone edits to Jira release

### DIFF
--- a/.github/workflows/main_sync_milestone_to_jira_release.yml
+++ b/.github/workflows/main_sync_milestone_to_jira_release.yml
@@ -1,4 +1,4 @@
-name: Create Jira releases (versions) from GitHub milestone
+name: Sync Jira releases (versions) from GitHub milestone
 
 on:
   workflow_call:
@@ -115,6 +115,124 @@ jobs:
             cat resp.json || true
             echo
             failed=$((failed+1))
+          done
+
+          echo "======================================================"
+          echo "Summary: ok=${ok} skipped=${skipped} failed=${failed}"
+          echo "======================================================"
+
+          if [ "$failed" -gt 0 ]; then
+            exit 1
+          fi
+
+
+  update_jira_releases:
+    if: github.event.action == 'edited'
+    runs-on: ubuntu-slim
+    env:
+      JIRA_BASE_URL: https://scylladb.atlassian.net
+      JIRA_AUTH: ${{ secrets.caller_jira_auth }}
+      PROJECT_KEYS: ${{ inputs.jira_project_keys }}
+
+    steps:
+      - name: Debug milestone input
+        run: |
+          echo "Projects:      '${{ inputs.jira_project_keys }}'"
+          echo "Title:         '${{ github.event.milestone.title }}'"
+          echo "Description:   '${{ github.event.milestone.description }}'"
+          echo "Due on:        '${{ github.event.milestone.due_on }}'"
+          echo "Action:        '${{ github.event.action }}'"
+
+      - name: Update Jira version details in each project
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -z "${JIRA_AUTH:-}" ]; then
+            echo "ERROR: jira_auth secret is not set."
+            exit 1
+          fi
+
+          NAME="${{ github.event.milestone.title }}"
+          DESC="${{ github.event.milestone.description }}"
+          DUE_ON="${{ github.event.milestone.due_on }}"
+
+          # GitHub due_on is ISO 8601; Jira expects YYYY-MM-DD
+          RELEASE_DATE=""
+          if [ -n "${DUE_ON:-}" ]; then
+            RELEASE_DATE="${DUE_ON%%T*}"
+          fi
+
+          echo "Version name:  ${NAME}"
+          echo "Description:   ${DESC:-<none>}"
+          echo "Release date:  ${RELEASE_DATE:-<none>}"
+          echo "Projects:      ${PROJECT_KEYS}"
+          echo
+
+          # Split comma-separated keys safely (trim whitespace)
+          IFS=',' read -r -a KEYS <<< "${PROJECT_KEYS}"
+
+          ok=0
+          skipped=0
+          failed=0
+
+          for raw in "${KEYS[@]}"; do
+            PROJECT_KEY="$(echo "$raw" | awk '{$1=$1};1')"  # trim
+            [ -n "$PROJECT_KEY" ] || continue
+
+            echo "======================================================"
+            echo "Updating Jira version in project: ${PROJECT_KEY}"
+            echo "======================================================"
+
+            # Find the version ID by name
+            HTTP_CODE=$(curl -sS -o versions.json -w "%{http_code}" \
+              "${JIRA_BASE_URL}/rest/api/3/project/${PROJECT_KEY}/versions" \
+              --user "${JIRA_AUTH}" \
+              -H "Accept: application/json" || true)
+
+            if [ "$HTTP_CODE" != "200" ]; then
+              echo "FAIL: could not list versions in ${PROJECT_KEY} (HTTP ${HTTP_CODE}). Response:"
+              cat versions.json || true
+              echo
+              failed=$((failed+1))
+              continue
+            fi
+
+            VERSION_ID=$(jq -r --arg name "$NAME" \
+              '.[] | select(.name == $name) | .id' versions.json | head -1)
+
+            if [ -z "$VERSION_ID" ]; then
+              echo "SKIP: version '${NAME}' not found in ${PROJECT_KEY}."
+              skipped=$((skipped+1))
+              continue
+            fi
+
+            # Build update payload with description and releaseDate
+            jq -n \
+              --arg desc "${DESC:-}" \
+              --arg rdate "${RELEASE_DATE:-}" \
+              '
+              {}
+              + (if $desc  != "" then {description: $desc} else {} end)
+              + (if $rdate != "" then {releaseDate: $rdate} else {releaseDate: null} end)
+              ' > update_payload.json
+
+            HTTP_CODE=$(curl -sS -o update_resp.json -w "%{http_code}" \
+              -X PUT "${JIRA_BASE_URL}/rest/api/3/version/${VERSION_ID}" \
+              --user "${JIRA_AUTH}" \
+              -H "Accept: application/json" \
+              -H "Content-Type: application/json" \
+              --data @update_payload.json || true)
+
+            if [ "$HTTP_CODE" = "200" ]; then
+              echo "OK: updated version '${NAME}' in ${PROJECT_KEY} (id=${VERSION_ID})."
+              ok=$((ok+1))
+            else
+              echo "FAIL: could not update version in ${PROJECT_KEY} (HTTP ${HTTP_CODE}). Response:"
+              cat update_resp.json || true
+              echo
+              failed=$((failed+1))
+            fi
           done
 
           echo "======================================================"


### PR DESCRIPTION
## Summary

Adds an `update_jira_releases` job to the reusable milestone sync workflow, triggered when a GitHub milestone is **edited**.

When a milestone's description or due date is updated, this job finds the corresponding Jira release version in each configured project and updates its description and/or release date accordingly.

## Changes

- Added `update_jira_releases` job (`if: github.event.action == 'edited'`) to `main_sync_milestone_to_jira_release.yml`
- Looks up the existing Jira version by name, then PUTs updated description/releaseDate
- Updated workflow name to reflect broader scope (create + update + release)

## Testing
was tested in staging https://github.com/scylladb/staging/pull/239, https://github.com/scylladb/github-automation/pull/189

Fixes: PM-282