### PR TITLE
ci: pin actions/checkout to full commit SHA

### DIFF
--- a/.github/workflows/main_pr_events_jira_sync.yml
+++ b/.github/workflows/main_pr_events_jira_sync.yml
@@ -24,7 +24,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: scylladb/github-automation
           ref: automation-staging-branch


### PR DESCRIPTION
## What

Pin `actions/checkout` to its full commit SHA in `main_pr_events_jira_sync.yml`.

```diff
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
```

## Why

The `scylladb` GitHub organisation enforces a policy that all actions must be pinned to a full 40-character commit SHA. Reusable workflows called from organisation repositories are subject to the same policy.

`main_pr_events_jira_sync.yml` is called from `scylladb/java-driver` via `call_jira_sync.yml`. Because this workflow used `actions/checkout@v4` (a tag ref), every PR targeting `scylla-4.x` in `java-driver` failed with:

```
Error: The action actions/checkout@v4 is not allowed in scylladb/java-driver
because all actions must be pinned to a full-length commit SHA.
```

Tracked in: scylladb/java-driver#911