### PR TITLE
fix: don't resolve parent JIRA issues when backport PRs are promoted

### DIFF
--- a/.github/scripts/auto-backport-jira.py
+++ b/.github/scripts/auto-backport-jira.py
@@ -1081,63 +1081,6 @@ def create_pull_request(repo, new_branch_name, base_branch_name, pr, backport_pr
             draft=is_draft
         )
         logging.info(f"Pull request created: {backport_pr.html_url}")
-        backport_pr.add_to_assignees(assignee)
-        logging.info(f"Assigned PR to: {assignee.login}")
-
-        if warn_missing_fixes:
-            warning_comment = (f"@{assignee.login} This backport PR can't be merged without a valid Fixes reference ")
-            backport_pr.create_issue_comment(warning_comment)
-        
-        # Add labels to the backport PR
-        labels_to_add = []
-        
-        # Check for priority labels (P0 or P1) in parent PR and add them to backport PR
-        # Skip force_on_cloud for scylla-pkg and RELENG projects
-        priority_labels = {"P0", "P1"}
-        parent_pr_labels = [label.name for label in pr.labels]
-        skip_force_on_cloud_repos = {"scylladb/scylla-pkg"}
-        for label in priority_labels:
-            if label in parent_pr_labels:
-                labels_to_add.append(label)
-                # Add force_on_cloud only for repos that need it (not scylla-pkg or RELENG)
-                if repo.full_name not in skip_force_on_cloud_repos:
-                    labels_to_add.append("force_on_cloud")
-                    logging.info(f"Adding {label} and force_on_cloud labels from parent PR to backport PR")
-                else:
-                    logging.info(f"Adding {label} label from parent PR to backport PR (skipping force_on_cloud for {repo.full_name})")
-                break  # Only apply the highest priority label
-        
-        # Add conflicts label if PR is in draft mode
-        if is_draft:
-            labels_to_add.append("conflicts")
-            pr_comment = f"@{assignee.login} - This PR has conflicts, therefore it was moved to `draft` \n"
-            pr_comment += "Please resolve them and mark this PR as ready for review by removing the conflicts label"
-            backport_pr.create_issue_comment(pr_comment)
-        
-        
-        # Note: promoted-to-<branch> label is NOT added here.
-        # It will be added by the workflow when the commit is actually pushed/promoted to the branch.
-        # This allows chain backports to trigger only after successful merge.
-        
-        # Add Jira failure label if sub-issue creation failed
-        if jira_failed:
-            labels_to_add.append(JIRA_FAILURE_LABEL)
-            logging.info(f"Adding {JIRA_FAILURE_LABEL} label due to Jira sub-issue creation failure")
-        
-        # Add remaining backport labels for chain continuation
-        if remaining_backport_labels:
-            labels_to_add.extend(remaining_backport_labels)
-            logging.info(f"Adding remaining backport labels for chain: {remaining_backport_labels}")
-            
-        # Apply all labels at once if we have any
-        if labels_to_add:
-            backport_pr.add_to_labels(*labels_to_add)
-            logging.info(f"Added labels to backport PR: {labels_to_add}")
-            
-        if backport_version:
-            milestone_title = resolve_backport_milestone_title(backport_version)
-            set_pr_milestone(backport_pr, milestone_title)
-        return backport_pr
     except GithubException as e:
         if 'A pull request already exists' in str(e):
             logging.warning(f'A pull request already exists for scylladbbot:{new_branch_name}')
@@ -1148,17 +1091,99 @@ def create_pull_request(repo, new_branch_name, base_branch_name, pr, backport_pr
                     logging.info(f"Found existing PR: {existing_pr.html_url}")
                     # Update the body with the latest info
                     existing_pr.edit(body=pr_body)
-                    if warn_missing_fixes:
-                        warning_comment = (f"@{assignee.login} This backport PR can't be merged without a valid Fixes reference ")
-                        existing_pr.create_issue_comment(warning_comment)
-                    if backport_version:
-                        milestone_title = resolve_backport_milestone_title(backport_version)
-                        set_pr_milestone(existing_pr, milestone_title)
-                    return existing_pr
+                    backport_pr = existing_pr
+                    break
+                else:
+                    logging.warning(f"Could not find existing PR for scylladbbot:{new_branch_name}")
+                    return None
             except Exception as find_error:
                 logging.warning(f"Could not find existing PR: {find_error}")
+                return None
         else:
             logging.error(f'Failed to create PR: {e}')
+            return None
+
+    # All post-creation operations are done outside the create_pull try block.
+    # This ensures that if any single operation fails, the others still proceed,
+    # and the PR object is always returned.
+
+    # Assign the PR to the original author with retry logic to handle
+    # transient GitHub API failures (e.g., secondary rate limits).
+    for attempt in range(3):
+        try:
+            backport_pr.add_to_assignees(assignee)
+            logging.info(f"Assigned PR to: {assignee.login}")
+            break
+        except Exception as e:
+            if attempt < 2:
+                logging.warning(f"Failed to assign PR to {assignee.login} (attempt {attempt + 1}/3): {e}")
+                time.sleep(2 ** attempt)  # Exponential backoff: 1s, 2s
+            else:
+                logging.error(f"Failed to assign PR to {assignee.login} after 3 attempts: {e}")
+
+    if warn_missing_fixes:
+        try:
+            warning_comment = (f"@{assignee.login} This backport PR can't be merged without a valid Fixes reference ")
+            backport_pr.create_issue_comment(warning_comment)
+        except Exception as e:
+            logging.warning(f"Failed to add missing-fixes warning comment: {e}")
+    
+    # Add labels to the backport PR
+    labels_to_add = []
+    
+    # Check for priority labels (P0 or P1) in parent PR and add them to backport PR
+    # Skip force_on_cloud for scylla-pkg and RELENG projects
+    priority_labels = {"P0", "P1"}
+    parent_pr_labels = [label.name for label in pr.labels]
+    skip_force_on_cloud_repos = {"scylladb/scylla-pkg"}
+    for label in priority_labels:
+        if label in parent_pr_labels:
+            labels_to_add.append(label)
+            # Add force_on_cloud only for repos that need it (not scylla-pkg or RELENG)
+            if repo.full_name not in skip_force_on_cloud_repos:
+                labels_to_add.append("force_on_cloud")
+                logging.info(f"Adding {label} and force_on_cloud labels from parent PR to backport PR")
+            else:
+                logging.info(f"Adding {label} label from parent PR to backport PR (skipping force_on_cloud for {repo.full_name})")
+            break  # Only apply the highest priority label
+    
+    # Add conflicts label if PR is in draft mode
+    if is_draft:
+        labels_to_add.append("conflicts")
+        try:
+            pr_comment = f"@{assignee.login} - This PR has conflicts, therefore it was moved to `draft` \n"
+            pr_comment += "Please resolve them and mark this PR as ready for review by removing the conflicts label"
+            backport_pr.create_issue_comment(pr_comment)
+        except Exception as e:
+            logging.warning(f"Failed to add conflicts comment: {e}")
+    
+    
+    # Note: promoted-to-<branch> label is NOT added here.
+    # It will be added by the workflow when the commit is actually pushed/promoted to the branch.
+    # This allows chain backports to trigger only after successful merge.
+    
+    # Add Jira failure label if sub-issue creation failed
+    if jira_failed:
+        labels_to_add.append(JIRA_FAILURE_LABEL)
+        logging.info(f"Adding {JIRA_FAILURE_LABEL} label due to Jira sub-issue creation failure")
+    
+    # Add remaining backport labels for chain continuation
+    if remaining_backport_labels:
+        labels_to_add.extend(remaining_backport_labels)
+        logging.info(f"Adding remaining backport labels for chain: {remaining_backport_labels}")
+        
+    # Apply all labels at once if we have any
+    if labels_to_add:
+        try:
+            backport_pr.add_to_labels(*labels_to_add)
+            logging.info(f"Added labels to backport PR: {labels_to_add}")
+        except Exception as e:
+            logging.error(f"Failed to add labels to backport PR: {e}")
+        
+    if backport_version:
+        milestone_title = resolve_backport_milestone_title(backport_version)
+        set_pr_milestone(backport_pr, milestone_title)
+    return backport_pr
 
 
 def _find_commit_on_stable_branch(repo, commit_sha: str, stable_branch: str) -> Optional[str]:

--- a/scripts/jira_sync_logic.py
+++ b/scripts/jira_sync_logic.py
@@ -82,10 +82,21 @@ def manage_labeled_gh_event(
     print("=" * 60)
     print(" Step 1 / extract_jira_keys")
     print("=" * 60)
-    keys = extract_jira_keys(pr_title, pr_body, jira_auth,
-                             owner_repo=owner_repo,
-                             pr_number=pr_number,
-                             gh_token=gh_token)
+    # For backport PRs with promoted-to-* labels, only extract keys from the PR body
+    # (not commit messages). Backport PR bodies contain the correct sub-task key
+    # (e.g., "Fixes: SCYLLADB-1171"), but the cherry-picked commits still reference
+    # the parent issue (e.g., "Fixes: SCYLLADB-1114"). Scanning commits would cause
+    # the parent issue to be incorrectly transitioned to Done. (RELENG-464)
+    import re as _re
+    _is_backport_pr = bool(_re.match(r'\[Backport (manager-)?\d+\.\d+\]', pr_title))
+    if _is_backport_pr and triggering_label.startswith("promoted-to-"):
+        print("Backport PR with promoted-to-* label: scanning PR body only (skipping commit messages)")
+        keys = extract_jira_keys(pr_title, pr_body, jira_auth)
+    else:
+        keys = extract_jira_keys(pr_title, pr_body, jira_auth,
+                                 owner_repo=owner_repo,
+                                 pr_number=pr_number,
+                                 gh_token=gh_token)
     jira_keys_json = json.dumps(keys)
     print(f"jira-keys-json={jira_keys_json}")
 
@@ -378,10 +389,21 @@ def manage_closed_gh_event(
     print("\n" + "=" * 60)
     print(" Step 1 / extract_jira_keys")
     print("=" * 60)
-    keys = extract_jira_keys(pr_title, pr_body, jira_auth,
-                             owner_repo=owner_repo,
-                             pr_number=pr_number,
-                             gh_token=gh_token)
+    # For backport PRs, only extract keys from the PR body (not commit messages).
+    # Backport PR bodies contain the correct sub-task key (e.g., "Fixes: SCYLLADB-1171"),
+    # but the cherry-picked commits still reference the parent issue
+    # (e.g., "Fixes: SCYLLADB-1114"). Scanning commits would cause the parent issue
+    # to be incorrectly transitioned to Done. (RELENG-464)
+    import re as _re
+    _is_backport_pr = bool(_re.match(r'\[Backport (manager-)?\d+\.\d+\]', pr_title))
+    if _is_backport_pr:
+        print("Backport PR detected: scanning PR body only (skipping commit messages)")
+        keys = extract_jira_keys(pr_title, pr_body, jira_auth)
+    else:
+        keys = extract_jira_keys(pr_title, pr_body, jira_auth,
+                                 owner_repo=owner_repo,
+                                 pr_number=pr_number,
+                                 gh_token=gh_token)
     jira_keys_json = json.dumps(keys)
     print(f"jira-keys-json={jira_keys_json}")
 


### PR DESCRIPTION
## Problem

When a backport PR is promoted to a release branch (receives a `promoted-to-*` label), the JIRA sync workflow (`manage_labeled_gh_event`) extracts JIRA keys from **both** the PR body AND commit messages, then transitions ALL found keys to Done.

For backport PRs:
- **PR body** correctly references the version-specific sub-task (e.g., `Fixes: SCYLLADB-1171`)
- **Commit messages** still contain the original parent reference (e.g., `Fixes: SCYLLADB-1114`) from the cherry-picked commit

This caused the **parent issue** (SCYLLADB-1114) to be:
1. Incorrectly transitioned to Done multiple times (once per backport promotion)
2. Receiving multiple 'Closed via promoted-to-*' comments

Evidence from SCYLLADB-1114's comment history:
- `2026-03-20`: Closed via promoted-to-master (correct - original PR)
- `2026-04-07`: Closed via promoted-to-branch-2026.1 (WRONG - should only affect sub-task SCYLLADB-1171)
- `2026-04-16`: Closed via promoted-to-branch-2025.4 (WRONG - should only affect sub-task SCYLLADB-1172)

## Root Cause

`extract_jira_keys()` scans commit messages for closing keywords (`Fixes:`, `Closes:`, etc.). Cherry-picked commits in backport PRs retain the parent issue reference from master. The workflow then treats both the sub-task (from body) and parent (from commits) as targets for Done transition.

## Fix

When the PR title indicates it's a backport PR (`[Backport X.Y] ...`), skip commit message scanning in `extract_jira_keys()`. Only use JIRA keys from the PR body, which always has the correct sub-task reference (set by `auto-backport-jira.py`'s `replace_fixes_in_body()` during backport PR creation).

Applied to both:
- `manage_labeled_gh_event` (handles `promoted-to-*` labels)
- `manage_closed_gh_event` (handles PR close/merge events)

Fixes: RELENG-464