### PR TITLE
main_pr_events_jira_sync: Pin github actions to specific hash

### DIFF
--- a/.github/workflows/main_pr_events_jira_sync.yml
+++ b/.github/workflows/main_pr_events_jira_sync.yml
@@ -24,7 +24,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: scylladb/github-automation
           ref: automation-staging-branch


### PR DESCRIPTION
Needed for enabling requiring actions to be pinned in drivers team repos.

Fixes: https://scylladb.atlassian.net/browse/DRIVER-515