### PR TITLE
PM-324: Stop scanning commit messages for Jira keys

### DIFF
--- a/scripts/jira_sync_logic.py
+++ b/scripts/jira_sync_logic.py
@@ -82,10 +82,7 @@ def manage_labeled_gh_event(
     print("=" * 60)
     print(" Step 1 / extract_jira_keys")
     print("=" * 60)
-    keys = extract_jira_keys(pr_title, pr_body, jira_auth,
-                             owner_repo=owner_repo,
-                             pr_number=pr_number,
-                             gh_token=gh_token)
+    keys = extract_jira_keys(pr_title, pr_body, jira_auth)
     jira_keys_json = json.dumps(keys)
     print(f"jira-keys-json={jira_keys_json}")
 
@@ -258,10 +255,7 @@ def manage_review_gh_event(
     print("\n" + "=" * 60)
     print(" Step 1 / extract_jira_keys")
     print("=" * 60)
-    keys = extract_jira_keys(pr_title, pr_body, jira_auth,
-                             owner_repo=owner_repo,
-                             pr_number=pr_number,
-                             gh_token=gh_token)
+    keys = extract_jira_keys(pr_title, pr_body, jira_auth)
     jira_keys_json = json.dumps(keys)
     print(f"jira-keys-json={jira_keys_json}")
 
@@ -378,10 +372,7 @@ def manage_closed_gh_event(
     print("\n" + "=" * 60)
     print(" Step 1 / extract_jira_keys")
     print("=" * 60)
-    keys = extract_jira_keys(pr_title, pr_body, jira_auth,
-                             owner_repo=owner_repo,
-                             pr_number=pr_number,
-                             gh_token=gh_token)
+    keys = extract_jira_keys(pr_title, pr_body, jira_auth)
     jira_keys_json = json.dumps(keys)
     print(f"jira-keys-json={jira_keys_json}")
 
@@ -531,10 +522,7 @@ def manage_opened_gh_event(
     print("\n" + "=" * 60)
     print(" Step 1 / extract_jira_keys")
     print("=" * 60)
-    keys = extract_jira_keys(pr_title, pr_body, jira_auth,
-                             owner_repo=owner_repo,
-                             pr_number=pr_number,
-                             gh_token=gh_token)
+    keys = extract_jira_keys(pr_title, pr_body, jira_auth)
     jira_keys_json = json.dumps(keys)
     print(f"jira-keys-json={jira_keys_json}")
 
@@ -670,10 +658,7 @@ def manage_unlabeled_gh_event(
     print("\n" + "=" * 60)
     print(" Step 1 / extract_jira_keys")
     print("=" * 60)
-    keys = extract_jira_keys(pr_title, pr_body, jira_auth,
-                             owner_repo=owner_repo,
-                             pr_number=pr_number,
-                             gh_token=gh_token)
+    keys = extract_jira_keys(pr_title, pr_body, jira_auth)
     jira_keys_json = json.dumps(keys)
     print(f"jira-keys-json={jira_keys_json}")
 


### PR DESCRIPTION
## PM-324: Don't trigger the sync automation on commit text

Fixes: [PM-324](https://scylladb.atlassian.net/browse/PM-324)

### What

Remove `owner_repo`, `pr_number`, and `gh_token` arguments from all 5 `extract_jira_keys()` call sites in `scripts/jira_sync_logic.py`. This stops the function from fetching PR commit messages and scanning them for Jira keys.

### Why

Commit message text was inadvertently triggering Jira sync automation. Only PR title and body should be used for Jira key extraction.

This is a partial rollback of [PM-279](https://scylladb.atlassian.net/browse/PM-279) ([PR #172](https://github.com/scylladb/github-automation/pull/172)).

### Changes

- `scripts/jira_sync_logic.py`: Removed `owner_repo=owner_repo, pr_number=pr_number, gh_token=gh_token` keyword arguments from `extract_jira_keys()` calls in all 5 orchestrator functions:
  - `manage_labeled_gh_event`  
  - `manage_review_gh_event`  
  - `manage_closed_gh_event`  
  - `manage_opened_gh_event`  
  - `manage_unlabeled_gh_event`

[PM-324]: https://scylladb.atlassian.net/browse/PM-324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-279]: https://scylladb.atlassian.net/browse/PM-279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ