### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/auto-assign-per-team.yml
+++ b/.github/workflows/auto-assign-per-team.yml
@@ -24,10 +24,10 @@ jobs:
             labels: "[]"
     steps:
       - name: checkout repo content
-        uses: actions/checkout@v4 # checkout the repository content
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11' # install the python version needed
 

--- a/.github/workflows/backport-tests.yaml
+++ b/.github/workflows/backport-tests.yaml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.12'
 
@@ -35,7 +35,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-results
           path: test-results.xml

--- a/.github/workflows/backport-with-jira.yaml
+++ b/.github/workflows/backport-with-jira.yaml
@@ -76,7 +76,7 @@ jobs:
           echo "pull_request_number: ${{ inputs.pull_request_number }}"
           
       - name: Checkout shared automation repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: scylladb/github-automation
           ref: main
@@ -84,7 +84,7 @@ jobs:
           path: automation
           
       - name: Checkout calling repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: ${{ github.repository }}
           ref: ${{ env.DEFAULT_BRANCH }}
@@ -288,7 +288,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout calling repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: ${{ github.repository }}
           ref: ${{ env.DEFAULT_BRANCH }}

--- a/.github/workflows/close_issue_for_scylla_employee.yml
+++ b/.github/workflows/close_issue_for_scylla_employee.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Comment and close if author email is scylladb.com
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/copilot-review.yaml
+++ b/.github/workflows/copilot-review.yaml
@@ -52,7 +52,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout automation scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: scylladb/github-automation
           path: .automation
@@ -71,7 +71,7 @@ jobs:
 
       - name: Setup Node.js
         if: inputs.tool == 'copilot'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
 
       - name: Install Copilot CLI
         if: inputs.tool == 'copilot'
@@ -119,7 +119,7 @@ jobs:
 
       - name: Upload review artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ai-review-PR${{ inputs.pr_number }}
           path: /tmp/copilot-review/

--- a/.github/workflows/daily-aws-instance-monitor.yml
+++ b/.github/workflows/daily-aws-instance-monitor.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.x'
 

--- a/.github/workflows/extract_jira_issue_details.yml
+++ b/.github/workflows/extract_jira_issue_details.yml
@@ -140,7 +140,7 @@ jobs:
 
       - name: Upload CSV artifact
         id: artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jira-details-csv
           path: jira-details.csv

--- a/.github/workflows/github-metrics-report.yml
+++ b/.github/workflows/github-metrics-report.yml
@@ -30,7 +30,7 @@ jobs:
         echo "last_week=$first_day..$last_day" >> "$GITHUB_ENV"
 
     - name: Run issue-metrics tool
-      uses: github/issue-metrics@v3.4.0
+      uses: github/issue-metrics@8ac1c540aad1771741b57b2ffb757b2f6433bb04 # v3.4.0
       env:
         GH_TOKEN:  ${{ secrets.ISSUE_ASSIGNMENT_TO_PROJECT_TOKEN }}
         SEARCH_QUERY: 'repo:scylladb/scylla-enterprise is:issue closed:${{ env.last_week }} reason:completed -label:documentation '
@@ -48,7 +48,7 @@ jobs:
       
 
     - name: Run issue-metrics tool
-      uses: github/issue-metrics@v3.4.0
+      uses: github/issue-metrics@8ac1c540aad1771741b57b2ffb757b2f6433bb04 # v3.4.0
       env:
         GH_TOKEN:  ${{ secrets.ISSUE_ASSIGNMENT_TO_PROJECT_TOKEN }}
         SEARCH_QUERY: 'repo:scylladb/scylla-enterprise is:pr closed:${{ env.last_week }} reason:completed -label:documentation '
@@ -65,7 +65,7 @@ jobs:
         markdown-style-theme: dark
 
     - name: Run issue-metrics tool
-      uses: github/issue-metrics@v3.4.0
+      uses: github/issue-metrics@8ac1c540aad1771741b57b2ffb757b2f6433bb04 # v3.4.0
       env:
         GH_TOKEN:  ${{ secrets.ISSUE_ASSIGNMENT_TO_PROJECT_TOKEN }}
         SEARCH_QUERY: 'repo:scylladb/scylla-enterprise closed:${{ env.last_week }} reason:completed -label:documentation '
@@ -83,7 +83,7 @@ jobs:
         
     - name: Send mail
       if: always()
-      uses: dawidd6/action-send-mail@v3
+      uses: dawidd6/action-send-mail@2cea9617b09d79a095af21254fbcb7ae95903dde # v3.12.0
       with:
         # mail server settings
         server_address: smtp.gmail.com

--- a/.github/workflows/main_create_jira_issue_from_gh_issue.yml
+++ b/.github/workflows/main_create_jira_issue_from_gh_issue.yml
@@ -22,7 +22,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout automation repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: scylladb/github-automation
           ref: main

--- a/.github/workflows/main_jira_sync_add_label.yml
+++ b/.github/workflows/main_jira_sync_add_label.yml
@@ -15,7 +15,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: scylladb/github-automation
           ref: main

--- a/.github/workflows/main_jira_sync_in_review.yml
+++ b/.github/workflows/main_jira_sync_in_review.yml
@@ -15,7 +15,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: scylladb/github-automation
           ref: main

--- a/.github/workflows/main_jira_sync_pr_closed.yml
+++ b/.github/workflows/main_jira_sync_pr_closed.yml
@@ -15,7 +15,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: scylladb/github-automation
           ref: main

--- a/.github/workflows/main_jira_sync_pr_opened.yml
+++ b/.github/workflows/main_jira_sync_pr_opened.yml
@@ -15,7 +15,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: scylladb/github-automation
           ref: main

--- a/.github/workflows/main_jira_sync_remove_label.yml
+++ b/.github/workflows/main_jira_sync_remove_label.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Checkout scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: scylladb/github-automation
           ref: main

--- a/.github/workflows/validate_pr_author_email.yml
+++ b/.github/workflows/validate_pr_author_email.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
@@ -18,7 +18,7 @@ jobs:
           git fetch origin ${{ github.event.pull_request.base.ref }}
 
       - name: Fetch allowed emails list
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: scylladb/github-automation
           sparse-checkout: .github/workflows/allowed_emails.txt
@@ -147,7 +147,7 @@ jobs:
 
       - name: Find existing validation comment
         if: always()
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: find_comment
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -156,7 +156,7 @@ jobs:
 
       - name: Post or update comment on PR
         if: failure() && steps.validate.outputs.found_invalid == 'true'
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           comment-id: ${{ steps.find_comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
@@ -167,7 +167,7 @@ jobs:
 
       - name: Delete resolved validation comment
         if: success() && steps.find_comment.outputs.comment-id != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             await github.rest.issues.deleteComment({
@@ -178,7 +178,7 @@ jobs:
 
       - name: Set commit status
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const state = '${{ steps.validate.outcome }}' === 'success' ? 'success' : 'failure';


### PR DESCRIPTION
## Summary
- Pin all external GitHub Actions to full commit SHAs to reduce supply chain attack surface
- Upgrade outdated actions to their latest versions

**This PR was generated automatically. Please verify that GitHub Actions work as expected with these changes before merging.**

Reference: https://github.com/scylladb/scylladb/pull/29421