### PR TITLE
backport-with-jira: gate resolve-conflicts on actual backport events

### DIFF
--- a/.github/workflows/backport-with-jira.yaml
+++ b/.github/workflows/backport-with-jira.yaml
@@ -67,6 +67,8 @@ jobs:
     permissions:
       pull-requests: write
       issues: write
+    outputs:
+      backport_performed: ${{ steps.set_backport_performed.outputs.backport_performed }}
     steps:
       - name: Dump inputs
         run: |
@@ -279,9 +281,30 @@ jobs:
             --chain-backport \
             --merged-pr "${{ inputs.pull_request_number }}"
 
+      - name: Determine if a backport was actually performed
+        id: set_backport_performed
+        run: |
+          # A backport is considered performed when the event could have created or
+          # processed backport PRs. This is used to gate the resolve-conflicts job
+          # so it does not run on irrelevant events (e.g., backport/none label,
+          # push to master, or non-backport chain merges).
+          # Push to master creates initial backport PRs -- conflicts there will be
+          # picked up on subsequent version-branch pushes or labeled events.
+          if [[ "${{ inputs.event_type }}" == "push" && "${{ steps.check_version_branch.outputs.is_version_branch }}" == "true" ]]; then
+            echo "backport_performed=true" >> $GITHUB_OUTPUT
+          elif [[ "${{ inputs.event_type }}" == "labeled" && "${{ steps.check_label.outputs.backport_label }}" == "true" \
+            && "${{ inputs.pr_state }}" == "closed" && "${{ steps.check_concurrent.outputs.should_skip }}" != "true" ]]; then
+            echo "backport_performed=true" >> $GITHUB_OUTPUT
+          elif [[ "${{ inputs.event_type }}" == "chain" && "${{ steps.check_backport.outputs.is_backport_pr }}" == "true" ]]; then
+            echo "backport_performed=true" >> $GITHUB_OUTPUT
+          else
+            echo "No backport performed for event_type=${{ inputs.event_type }}, skipping resolve-conflicts."
+            echo "backport_performed=false" >> $GITHUB_OUTPUT
+          fi
+
   resolve-conflicts:
     needs: backport
-    if: always()
+    if: always() && needs.backport.outputs.backport_performed == 'true'
     runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       pull-requests: write


### PR DESCRIPTION
The resolve-conflicts job previously ran on every workflow trigger due to `if: always()`, including when non-backport labels like backport/none were added. This wasted CI resources and tokens resolving conflicts that didn't need resolution at that point.

Add a backport_performed output to the backport job that is only set to true when:
- A push to a version branch (not master) triggers chain continuation
- A valid backport/X.Y label is added to a closed PR
- A backport PR is merged (chain event)

Push to master is excluded because it creates initial backport PRs -- any conflicts there will be picked up on subsequent version-branch pushes or labeled events.

Fixes: RELENG-681