### PR TITLE
auto-backport-jira: fix Fixes: reference not being replaced with sub-task

### DIFF
--- a/.github/scripts/auto-backport-jira.py
+++ b/.github/scripts/auto-backport-jira.py
@@ -1066,9 +1066,10 @@ def replace_fixes_in_body(original_body: str, jira_mapping: Dict[str, str]) -> s
     
     # Match Jira Fixes patterns:
     #   "Fixes: PROJ-123"
+    #   "Fixes PROJ-123"
     #   "Fixes: https://...browse/PROJ-123"
     #   "Fixes: [PROJ-123](https://...browse/PROJ-123)"
-    jira_pattern = r'([Ff]ixes:\s*)(?:\[([A-Z]+-\d+)\]\([^)]*\)|(?:https?://[^\s/]+/browse/)?([A-Z]+-\d+))'
+    jira_pattern = r'([Ff]ixes:?\s*)(?:\[([A-Z]+-\d+)\]\([^)]*\)|(?:https?://[^\s/]+/browse/)?([A-Z]+-\d+))'
     
     def replace_match(match):
         prefix = match.group(1)  # "Fixes: "

--- a/.github/tests/test_pr_body_generation.py
+++ b/.github/tests/test_pr_body_generation.py
@@ -93,6 +93,17 @@ class TestReplaceFixesInBody:
         assert "RELENG-121" not in result
         assert "RELENG-396" not in result
 
+    def test_replacement_without_colon(self, bp_module):
+        # PR bodies sometimes omit the colon, e.g. "Fixes SCYLLADB-123" instead
+        # of "Fixes: SCYLLADB-123". The replacement must still fire, otherwise
+        # backport PRs keep pointing at the parent issue instead of the
+        # version-specific sub-task.
+        body = "Some text\nFixes SCYLLADB-2114\nMore text"
+        mapping = {"SCYLLADB-2114": "SCYLLADB-2602"}
+        result = bp_module.replace_fixes_in_body(body, mapping)
+        assert "SCYLLADB-2602" in result
+        assert "SCYLLADB-2114" not in result
+
     def test_no_mapping_preserves_body(self, bp_module):
         body = "Fixes: SCYLLADB-123"
         result = bp_module.replace_fixes_in_body(body, {})


### PR DESCRIPTION
replace_fixes_in_body() only matched "Fixes:" with a colon, but the
other helpers (extract_all_jira_keys_from_pr_body, has_fixes_reference)
treat the colon as optional. PRs written as "Fixes SCYLLADB-123" (no
colon) got their Jira key picked up fine and a sub-task created for the
backport version, but the swap in the PR body never happened, so the
backport PR kept pointing at the parent issue instead of the sub-task.

Fixes: RELENG-722