### PR TITLE
backport-with-jira: recognize old "Parent PR:" format in chain check

### DIFF
--- a/.github/workflows/backport-with-jira.yaml
+++ b/.github/workflows/backport-with-jira.yaml
@@ -254,8 +254,10 @@ jobs:
         env:
           PR_BODY: ${{ inputs.pr_body }}
         run: |
-          # Check if this is a backport PR (has "backport of PR" in body or [Backport X.Y] in title)
-          if echo "$PR_BODY" | grep -qi "backport of PR"; then
+          # Check if this is a backport PR. Body may use either the new format
+          # ("backport of PR ...") or the old format ("Parent PR: #1234") --
+          # keep this in sync with is_backport_pr() in auto-backport-jira.py.
+          if echo "$PR_BODY" | grep -qiE "backport of PR|Parent PR:\s*#[0-9]+"; then
             echo "is_backport_pr=true" >> $GITHUB_OUTPUT
           else
             echo "is_backport_pr=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- The reusable `backport-with-jira.yaml` workflow's chain job determines whether a merged PR is a backport PR via a bash `grep` on the PR body for the literal string `"backport of PR"`.
- Backport PRs created with the older body format (`Parent PR: #1234`, still emitted by `auto-backport-jira.py` today, e.g. `scylladb/scylladb#30849`) are not matched, so `is_backport_pr` evaluates to `false` and the "Process backport PR merge" step is skipped entirely -- no error, no log, the cascade just silently stops.
- This broke the 2026.2 -> 2026.1 chained backport for `scylladb/scylladb#30712`: the 2026.2 backport (#30849) merged, but its remaining `backport/2026.1` label was never picked up to open the next hop.
- `is_backport_pr()` in `auto-backport-jira.py` already matches both the new (`backport of PR`) and old (`Parent PR: #N`) formats. This aligns the workflow's bash check with that logic instead of duplicating a stale subset of it.

## Related
Root-caused while investigating [RELENG-761](https://scylladb.atlassian.net/browse/RELENG-761), where an earlier fix (#206, retry logic in `search_commits.py`) resolved a separate transient-API-error issue but this second bug is why the 2026.1 backport for PR #30712 still hasn't been created.

Fixes: RELENG-761

[RELENG-761]: https://scylladb.atlassian.net/browse/RELENG-761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ