### PR TITLE
auto-backport-jira: fix the backport chain, and inherit Team / schedule backport issues in Jira

### DIFF
--- a/.github/scripts/auto-backport-jira.py
+++ b/.github/scripts/auto-backport-jira.py
@@ -60,6 +60,13 @@ BACKPORT_LINK_TYPE = "Relates"
 # Jira Cloud, so these hold for every project the automation touches (RELENG,
 # SCYLLADB, DTEST, ...), as long as the field is on that project's screen.
 JIRA_TEAM_FIELD = "customfield_10001"
+JIRA_SPRINT_FIELD = "customfield_10020"
+JIRA_STORY_POINTS_FIELD = "customfield_10036"
+# Backport issues carry no estimate of their own -- the work was estimated on the
+# original issue -- so they land in the sprint with a zero estimate.
+BACKPORT_STORY_POINTS = 0
+# project key -> active sprint id (or None), resolved once per run
+_active_sprint_cache = {}
 SCYLLADB_REPO_NAME = "scylladb/scylladb"
 SCYLLA_PKG_REPO_NAME = "scylladb/scylla-pkg"
 SCYLLA_CLUSTER_TESTS_REPO_NAME = "scylladb/scylla-cluster-tests"
@@ -370,13 +377,19 @@ def set_pr_milestone(pr, milestone_title: Optional[str]) -> bool:
 # Jira API functions
 # ============================================================================
 
-def jira_api_request(method: str, endpoint: str, data: dict = None) -> Optional[dict]:
-    """Make a request to Jira API."""
+def jira_api_request(method: str, endpoint: str, data: dict = None,
+                     api_base: str = "api/3") -> Optional[dict]:
+    """
+    Make a request to Jira API.
+
+    api_base selects the API family: 'api/3' for the platform REST API (the default)
+    or 'agile/1.0' for the Jira Software (Agile) API, which owns boards and sprints.
+    """
     if not JIRA_USER or not JIRA_API_TOKEN:
         logging.warning("Jira credentials not configured")
         return None
-    
-    url = f"{JIRA_BASE_URL}/rest/api/3/{endpoint}"
+
+    url = f"{JIRA_BASE_URL}/rest/{api_base}/{endpoint}"
     auth_string = base64.b64encode(f"{JIRA_USER}:{JIRA_API_TOKEN}".encode()).decode()
     headers = {
         "Authorization": f"Basic {auth_string}",
@@ -816,6 +829,83 @@ def create_jira_linked_issue(parent_key: str, version: str, original_title: str,
         logging.warning(f"Created {new_key} but failed to link it to {parent_key}")
 
     return new_key
+
+
+def find_active_sprint_id(project_key: str) -> Optional[int]:
+    """
+    Find the id of the sprint currently running for a project, by asking the Agile
+    API for the project's boards and taking the first one with an active sprint.
+
+    Returns None when the project has no scrum board or is between sprints -- both
+    are normal, and simply mean the issue stays in the backlog.
+    """
+    if project_key in _active_sprint_cache:
+        return _active_sprint_cache[project_key]
+
+    sprint_id = None
+    try:
+        boards = jira_api_request("GET", f"board?projectKeyOrId={project_key}", api_base="agile/1.0")
+        for board in (boards or {}).get("values", []):
+            board_id = board.get("id")
+            if board_id is None:
+                continue
+            # Kanban boards have no sprints and answer this with an error
+            sprints = jira_api_request("GET", f"board/{board_id}/sprint?state=active",
+                                       api_base="agile/1.0")
+            for sprint in (sprints or {}).get("values", []):
+                sprint_id = sprint.get("id")
+                if sprint_id is not None:
+                    logging.info(f"Active sprint for {project_key}: {sprint.get('name')} (id {sprint_id})")
+                    break
+            if sprint_id is not None:
+                break
+        else:
+            logging.info(f"No active sprint found for project {project_key}")
+    except Exception as e:
+        logging.warning(f"Error looking up the active sprint for {project_key}: {e}")
+
+    _active_sprint_cache[project_key] = sprint_id
+    return sprint_id
+
+
+def schedule_backport_issue(issue_key: str) -> bool:
+    """
+    Put a backport issue into the current sprint with a zero estimate, so it shows up
+    on the board as soon as its backport PR is open instead of sitting in the backlog.
+
+    Best-effort: a failure here must never break the backport itself.
+    """
+    sprint_id = find_active_sprint_id(extract_project_from_jira_key(issue_key))
+
+    fields = {JIRA_STORY_POINTS_FIELD: BACKPORT_STORY_POINTS}
+    if sprint_id is not None:
+        fields[JIRA_SPRINT_FIELD] = sprint_id
+
+    result = jira_api_request("PUT", f"issue/{issue_key}", {"fields": fields})
+    if result is None and sprint_id is not None:
+        # Some board configurations reject a bare sprint id and want a list
+        fields[JIRA_SPRINT_FIELD] = [sprint_id]
+        result = jira_api_request("PUT", f"issue/{issue_key}", {"fields": fields})
+
+    if result is None:
+        logging.warning(f"Could not set sprint/story points on {issue_key}")
+        return False
+
+    logging.info(f"Set {issue_key} to sprint {sprint_id} with {BACKPORT_STORY_POINTS} story points")
+    return True
+
+
+def schedule_backport_issues(jira_mapping: Dict[str, str]):
+    """
+    Schedule every backport issue in jira_mapping. Entries where the backport issue
+    could not be resolved map a parent key to itself -- skip those, the parent issue
+    keeps its own sprint and estimate.
+    """
+    if not JIRA_USER or not JIRA_API_TOKEN:
+        return
+    for parent_key, backport_key in (jira_mapping or {}).items():
+        if backport_key and backport_key != parent_key:
+            schedule_backport_issue(backport_key)
 
 
 def add_jira_comment(issue_key: str, comment: str) -> bool:
@@ -1609,11 +1699,16 @@ def backport(repo, pr, version, commits, backport_base_branch, pr_body=None, jir
                     except GitCommandError as e:
                         logging.warning(f"Failed to amend commit message: {e}")
             repo_local.git.push(fork_repo, new_branch_name, force=True)
-            return create_pull_request(repo, new_branch_name, backport_base_branch, pr, backport_pr_title, commits,
+            backport_pr = create_pull_request(repo, new_branch_name, backport_base_branch, pr, backport_pr_title, commits,
                                 is_draft=is_draft, pr_body=pr_body, jira_failed=jira_failed,
                                 remaining_backport_labels=remaining_backport_labels,
                                 original_pr=original_pr, warn_missing_fixes=warn_missing_fixes,
                                 backport_version=version)
+            # The backport issues are created up front for every version, but only
+            # become actual work once their PR exists -- schedule them at that point.
+            if backport_pr:
+                schedule_backport_issues(jira_mapping)
+            return backport_pr
         except GitCommandError as e:
             logging.warning(f"GitCommandError: {e}")
             return None

--- a/.github/scripts/auto-backport-jira.py
+++ b/.github/scripts/auto-backport-jira.py
@@ -1908,8 +1908,13 @@ def process_chain_backport(repo, merged_pr, repo_name: str, promoted_commit_sha:
     
     # Get Jira key for this version - try to create sub-issue or use main Jira
     main_jira_key = extract_main_jira_from_body(pr_body)
-    main_pr_link = extract_main_pr_link_from_body(pr_body)
-    
+    # Backports are chained (waterfall): master -> 2026.3 -> 2026.2. The parent of the
+    # PR we are about to create is the PR we just merged, NOT the root original PR --
+    # that is also the branch the commit is cherry-picked from. Do not reuse the
+    # 'Parent PR:' reference found in pr_body, which points one step further up the
+    # chain. get_root_original_pr() walks the chain up whenever the root is needed.
+    main_pr_link = f"#{merged_pr.number}"
+
     # Get Jira accountId for the original PR author to assign sub-issues
     # Trace back to the root original PR to get the actual author (not a bot)
     assignee_account_id = None
@@ -2008,13 +2013,6 @@ def process_chain_backport(repo, merged_pr, repo_name: str, promoted_commit_sha:
     original_pr_body = original_pr.body if original_pr else merged_pr.body
     
     # Generate PR body for next backport
-    # Resolve the main PR link: prefer extracted link from body, then root original PR,
-    # then fall back to the merged PR number.
-    if not main_pr_link:
-        if original_pr:
-            main_pr_link = f"#{original_pr.number}"
-        else:
-            main_pr_link = f"#{merged_pr.number}"
     new_pr_body = generate_backport_pr_body(
         original_pr_body=original_pr_body,
         main_pr_link=main_pr_link,

--- a/.github/scripts/auto-backport-jira.py
+++ b/.github/scripts/auto-backport-jira.py
@@ -56,6 +56,10 @@ JIRA_FAILURE_LABEL = "jira-sub-issue-creation-failed"
 # instead of Jira's native sub-task hierarchy)
 BACKPORT_ISSUE_TYPE = "Task"
 BACKPORT_LINK_TYPE = "Relates"
+# Custom field ids on scylladb.atlassian.net. Custom field ids are site-global in
+# Jira Cloud, so these hold for every project the automation touches (RELENG,
+# SCYLLADB, DTEST, ...), as long as the field is on that project's screen.
+JIRA_TEAM_FIELD = "customfield_10001"
 SCYLLADB_REPO_NAME = "scylladb/scylladb"
 SCYLLA_PKG_REPO_NAME = "scylladb/scylla-pkg"
 SCYLLA_CLUSTER_TESTS_REPO_NAME = "scylladb/scylla-cluster-tests"
@@ -670,6 +674,46 @@ def get_parent_key_if_subtask(issue: dict) -> Optional[str]:
     return None
 
 
+def get_issue_team_id(issue: dict) -> Optional[str]:
+    """
+    Read the Team field of a Jira issue.
+
+    The 'atlassian-team' field reads back as an object ({'id': ..., 'name': ...})
+    but is written as the bare team id.
+    """
+    try:
+        team = issue.get("fields", {}).get(JIRA_TEAM_FIELD)
+    except Exception:
+        return None
+    if isinstance(team, dict):
+        return team.get("id")
+    # Older/simpler configurations store the id directly
+    return team if isinstance(team, str) else None
+
+
+def resolve_parent_team_id(parent_key: str) -> Optional[str]:
+    """
+    Find the Team a backport issue should inherit, starting from parent_key and
+    falling back to its parent when parent_key is a legacy sub-task that carries
+    no Team of its own.
+    """
+    parent_issue = get_jira_issue(parent_key)
+    if not parent_issue:
+        return None
+
+    team_id = get_issue_team_id(parent_issue)
+    if team_id:
+        return team_id
+
+    grandparent_key = get_parent_key_if_subtask(parent_issue)
+    if grandparent_key:
+        grandparent_issue = get_jira_issue(grandparent_key)
+        if grandparent_issue:
+            return get_issue_team_id(grandparent_issue)
+
+    return None
+
+
 def create_jira_linked_issue(parent_key: str, version: str, original_title: str, assignee_account_id: str = None) -> Optional[str]:
     """
     Create a Jira issue for a backport, linked to the original via a
@@ -744,7 +788,23 @@ def create_jira_linked_issue(parent_key: str, version: str, original_title: str,
     if assignee_account_id:
         issue_data["fields"]["assignee"] = {"accountId": assignee_account_id}
 
+    # Inherit the Team from the issue being backported. Backport issues used to be
+    # Jira sub-tasks, which inherited Team implicitly; as standalone linked issues
+    # they no longer do, and drop out of team-based filters unless we copy it over.
+    team_id = resolve_parent_team_id(parent_key)
+    if team_id:
+        issue_data["fields"][JIRA_TEAM_FIELD] = team_id
+        logging.info(f"Backport issue for {parent_key} will inherit team {team_id}")
+    else:
+        logging.info(f"No Team field on {parent_key}, backport issue will be created without one")
+
     result = jira_api_request("POST", "issue", issue_data)
+    if (not result or "key" not in result) and team_id:
+        # The Team field may not be on this project's create screen; a backport issue
+        # without a Team still beats no backport issue at all.
+        logging.warning(f"Creating backport issue for {parent_key} with a Team failed, retrying without it")
+        del issue_data["fields"][JIRA_TEAM_FIELD]
+        result = jira_api_request("POST", "issue", issue_data)
     if not result or "key" not in result:
         logging.error(f"Failed to create Jira backport issue for {parent_key} version {version}")
         return None

--- a/.github/scripts/auto-backport-jira.py
+++ b/.github/scripts/auto-backport-jira.py
@@ -2077,6 +2077,31 @@ def get_promoted_label(base_branch: str) -> str:
     return f'promoted-to-{base_branch}'
 
 
+def is_gating_branch(branch_name: str) -> bool:
+    """
+    Whether merging a PR into this branch is a merge only, not a promotion.
+
+    - 'next'     gates master (scylladb/scylladb)
+    - 'next-X.Y' gates branch-X.Y (scylla-pkg, scylla-dtest, scylla-machine-image)
+
+    Stable branches (master, branch-X.Y, manager-X.Y) are not gated: landing there
+    IS the promotion.
+    """
+    return branch_name == 'next' or branch_name.startswith('next-')
+
+
+def is_promoted(pr) -> bool:
+    """
+    Whether the commits of a PR merged into a gating branch have already been
+    promoted to the matching stable branch, i.e. the PR carries the
+    'promoted-to-<stable branch>' label added by process_branch_push().
+    """
+    if not is_gating_branch(pr.base.ref):
+        return True
+    promoted_label = get_promoted_label(pr.base.ref)
+    return promoted_label in {label.name for label in pr.labels}
+
+
 def process_branch_push(repo, commits_range: str, branch_name: str, repo_name: str):
     """
     Process a push event to a stable branch (e.g., master, branch-2025.4, or manager-3.4).
@@ -2337,10 +2362,22 @@ def main():
     # Handle chain backport mode (legacy - for PR merge events)
     if args.chain_backport and args.merged_pr:
         merged_pr = repo.get_pull(args.merged_pr)
-        if merged_pr.merged:
-            process_chain_backport(repo, merged_pr, repo_name)
-        else:
+        if not merged_pr.merged:
             logging.warning(f"PR #{args.merged_pr} is not merged, skipping chain processing")
+            return
+        # In gated repos a backport PR is first merged into next-X.Y and only later
+        # promoted to branch-X.Y. Continuing the chain on the merge event would
+        # backport a commit that has not been released yet, so wait for the
+        # 'promoted-to-branch-X.Y' label. process_branch_push() picks the PR up again
+        # when the promotion push lands and resumes the chain from there.
+        if not is_promoted(merged_pr):
+            logging.info(
+                f"PR #{merged_pr.number} was merged into gating branch {merged_pr.base.ref} but is "
+                f"not promoted yet (no '{get_promoted_label(merged_pr.base.ref)}' label); "
+                f"waiting for promotion before continuing the chain"
+            )
+            return
+        process_chain_backport(repo, merged_pr, repo_name)
         return
     
     closed_prs = []

--- a/.github/scripts/auto-backport-jira.py
+++ b/.github/scripts/auto-backport-jira.py
@@ -615,12 +615,15 @@ def find_existing_linked_issue(parent_key: str, version: str) -> Optional[str]:
                     return existing_key
 
         # Current method: issues linked to parent_key
+        # 'fields' must be requested explicitly: the search/jql endpoint returns only
+        # 'id' and 'key' by default, which would make the summary lookup below fail.
         jql = f'issue in linkedIssues("{parent_key}") AND summary ~ "Backport {version}"'
-        result = jira_api_request("POST", "search/jql", data={"jql": jql, "maxResults": 10})
+        result = jira_api_request("POST", "search/jql",
+                                  data={"jql": jql, "maxResults": 10, "fields": ["summary"]})
 
         if result and result.get("issues"):
             for issue in result["issues"]:
-                summary = issue["fields"]["summary"]
+                summary = issue.get("fields", {}).get("summary", "")
                 if _summary_matches_version(summary, version):
                     existing_key = issue["key"]
                     logging.info(f"Found existing linked Jira issue for {parent_key} version {version}: {existing_key} (via JQL)")

--- a/.github/tests/test_backport_orchestration.py
+++ b/.github/tests/test_backport_orchestration.py
@@ -45,6 +45,46 @@ class TestBackportFunction:
             mock_local_repo.git.cherry_pick.assert_called()
             mock_local_repo.git.push.assert_called_once()
 
+    def test_schedules_backport_issues_once_the_pr_exists(self, bp_module, make_pr, make_repo, make_commit):
+        """The Jira backport issues are created up front for every version; they only
+        become current work when their PR is opened."""
+        repo = make_repo()
+        pr = make_pr(number=10, title="Fix bug")
+        repo.get_commit.return_value = make_commit(sha="abc123", parents=[MagicMock()])
+        mapping = {"RELENG-785": "RELENG-800"}
+        mock_local_repo = MagicMock()
+        mock_local_repo.git.log.return_value = "Fix bug\n\nFixes: RELENG-785\n"
+
+        with patch.object(bp_module, "is_commit_in_branch", return_value=False), \
+             patch("tempfile.TemporaryDirectory") as mock_tmp, \
+             patch.object(bp_module.Repo, "clone_from", return_value=mock_local_repo), \
+             patch.object(bp_module, "create_pull_request", return_value=make_pr(number=42)), \
+             patch.object(bp_module, "schedule_backport_issues") as mock_sched:
+            mock_tmp.return_value.__enter__ = MagicMock(return_value="/tmp/test")
+            mock_tmp.return_value.__exit__ = MagicMock(return_value=False)
+
+            bp_module.backport(repo, pr, "2025.4", ["abc123"], "branch-2025.4", jira_mapping=mapping)
+            mock_sched.assert_called_once_with(mapping)
+
+    def test_does_not_schedule_when_pr_creation_fails(self, bp_module, make_pr, make_repo, make_commit):
+        repo = make_repo()
+        pr = make_pr(number=10, title="Fix bug")
+        repo.get_commit.return_value = make_commit(sha="abc123", parents=[MagicMock()])
+        mock_local_repo = MagicMock()
+        mock_local_repo.git.log.return_value = "Fix bug\n\nFixes: RELENG-785\n"
+
+        with patch.object(bp_module, "is_commit_in_branch", return_value=False), \
+             patch("tempfile.TemporaryDirectory") as mock_tmp, \
+             patch.object(bp_module.Repo, "clone_from", return_value=mock_local_repo), \
+             patch.object(bp_module, "create_pull_request", return_value=None), \
+             patch.object(bp_module, "schedule_backport_issues") as mock_sched:
+            mock_tmp.return_value.__enter__ = MagicMock(return_value="/tmp/test")
+            mock_tmp.return_value.__exit__ = MagicMock(return_value=False)
+
+            bp_module.backport(repo, pr, "2025.4", ["abc123"], "branch-2025.4",
+                               jira_mapping={"RELENG-785": "RELENG-800"})
+            mock_sched.assert_not_called()
+
     def test_cherry_pick_conflict_creates_draft(self, bp_module, make_pr, make_repo, make_commit):
         repo = make_repo()
         pr = make_pr(number=10, title="Fix bug")

--- a/.github/tests/test_branch_naming.py
+++ b/.github/tests/test_branch_naming.py
@@ -201,3 +201,35 @@ class TestBackportLabelAndTitlePatterns:
 
     def test_extract_original_title_perf(self, bp_module):
         assert bp_module.extract_original_title("[Backport perf-v15] Fix bug") == "Fix bug"
+
+
+class TestGatingBranch:
+    def test_next_is_gating(self, bp_module):
+        assert bp_module.is_gating_branch("next") is True
+
+    def test_next_version_is_gating(self, bp_module):
+        assert bp_module.is_gating_branch("next-2026.3") is True
+
+    def test_stable_branches_are_not_gating(self, bp_module):
+        assert bp_module.is_gating_branch("master") is False
+        assert bp_module.is_gating_branch("branch-2026.3") is False
+        assert bp_module.is_gating_branch("manager-3.4") is False
+        assert bp_module.is_gating_branch("branch-perf-v15") is False
+
+
+class TestIsPromoted:
+    def test_stable_branch_is_always_promoted(self, bp_module, make_pr):
+        pr = make_pr(base_ref="branch-2026.3", labels=[])
+        assert bp_module.is_promoted(pr) is True
+
+    def test_gating_branch_without_label(self, bp_module, make_pr):
+        pr = make_pr(base_ref="next-2026.3", labels=["backport/2026.2"])
+        assert bp_module.is_promoted(pr) is False
+
+    def test_gating_branch_with_label(self, bp_module, make_pr):
+        pr = make_pr(base_ref="next-2026.3", labels=["promoted-to-branch-2026.3"])
+        assert bp_module.is_promoted(pr) is True
+
+    def test_next_gates_on_master(self, bp_module, make_pr):
+        assert bp_module.is_promoted(make_pr(base_ref="next", labels=[])) is False
+        assert bp_module.is_promoted(make_pr(base_ref="next", labels=["promoted-to-master"])) is True

--- a/.github/tests/test_chain_backport.py
+++ b/.github/tests/test_chain_backport.py
@@ -272,15 +272,14 @@ class TestProcessChainBackport:
             mock_assign.assert_called_once_with("SCYLLADB-888", "user-id")
             mock_create.assert_not_called()
 
-    def test_chain_backport_uses_parent_pr_format_for_pr_link(self, bp_module, make_pr, make_repo):
-        """Chain backport from a PR using 'Parent PR: #N' format should correctly
-        resolve the original PR link, not fall back to the merged PR number.
-        
-        Regression test for: https://scylladb.atlassian.net/browse/DTEST-162
-        PR #6800 (2026.1 backport) had 'Parent PR: #6398'. When chain-backporting
-        to 2025.4, the automation incorrectly used #6800 as the parent PR instead
-        of #6398 because extract_main_pr_link_from_body didn't handle the
-        'Parent PR' format.
+    def test_chain_backport_parent_pr_is_the_merged_backport_pr(self, bp_module, make_pr, make_repo):
+        """Backports are chained (waterfall), so each backport PR's 'Parent PR' is the
+        PR it was cherry-picked from -- the backport PR that was just merged -- not the
+        root original PR one step further up the chain.
+
+        The parent link must match the branch the commits actually come from, otherwise
+        the chain reads as if 2025.4 was cherry-picked from master instead of 2026.1.
+        get_root_original_pr() walks the chain up whenever the root PR is needed.
         """
         repo = make_repo()
         # Original PR (e.g., #6398)
@@ -311,16 +310,16 @@ class TestProcessChainBackport:
 
             mock_bp.assert_called_once()
             pr_body = captured_pr_body['body']
-            # Parent PR should point to original #6398, not intermediate #6800
-            assert "Parent PR: #6398" in pr_body, f"Expected 'Parent PR: #6398' but got body:\n{pr_body}"
-            assert "Parent PR: #6800" not in pr_body
+            # Parent PR should point to the merged 2026.1 backport #6800, not the root #6398
+            assert "Parent PR: #6800" in pr_body, f"Expected 'Parent PR: #6800' but got body:\n{pr_body}"
+            assert "Parent PR: #6398" not in pr_body
             # Fixes should reference the sub-issue DTEST-162, not the parent DTEST-93
             assert "DTEST-162" in pr_body
             assert "DTEST-93" not in pr_body
 
-    def test_chain_backport_fallback_to_original_pr_when_no_link(self, bp_module, make_pr, make_repo):
-        """When neither 'backport of PR' nor 'Parent PR' is found in body,
-        should fall back to the root original PR number, not the merged PR."""
+    def test_chain_backport_parent_pr_when_body_has_no_link(self, bp_module, make_pr, make_repo):
+        """The parent link comes from the merged PR itself, so a body without any
+        'backport of PR' / 'Parent PR' reference still yields the merged PR number."""
         repo = make_repo()
         original = make_pr(number=100, title="Fix bug", body="Fix\nFixes: PROJ-1")
         # Merged PR with no parent PR link in body (edge case)
@@ -348,9 +347,9 @@ class TestProcessChainBackport:
             bp_module.process_chain_backport(repo, merged_pr, "scylladb/scylladb")
 
             pr_body = captured_pr_body['body']
-            # Should fall back to original PR #100, not merged PR #200
-            assert "Parent PR: #100" in pr_body, f"Expected 'Parent PR: #100' but got body:\n{pr_body}"
-            assert "Parent PR: #200" not in pr_body
+            # Should use the merged backport PR #200, not the root original PR #100
+            assert "Parent PR: #200" in pr_body, f"Expected 'Parent PR: #200' but got body:\n{pr_body}"
+            assert "Parent PR: #100" not in pr_body
 
 
 class TestProcessBranchPush:

--- a/.github/tests/test_jira_functions.py
+++ b/.github/tests/test_jira_functions.py
@@ -359,6 +359,24 @@ class TestFindExistingLinkedIssue:
             jql_arg = mock_jql.call_args.kwargs["data"]["jql"]
             assert 'linkedIssues("SCYLLADB-100")' in jql_arg
 
+    def test_jql_requests_summary_field(self, bp_module):
+        """search/jql returns only 'id' and 'key' unless fields are requested explicitly.
+        Without 'summary' the lookup raised KeyError('fields') and every chained backport
+        silently fell back to the parent Jira key."""
+        parent_issue = {"fields": {"subtasks": []}}
+        with patch.object(bp_module, "get_jira_issue", return_value=parent_issue), \
+             patch.object(bp_module, "jira_api_request", return_value={"issues": []}) as mock_jql:
+            bp_module.find_existing_linked_issue("SCYLLADB-100", "2025.4")
+            assert mock_jql.call_args.kwargs["data"]["fields"] == ["summary"]
+
+    def test_issue_without_fields_is_skipped(self, bp_module):
+        """A result row missing 'fields' must not raise -- it just doesn't match."""
+        parent_issue = {"fields": {"subtasks": []}}
+        jql_result = {"issues": [{"key": "SCYLLADB-999"}]}
+        with patch.object(bp_module, "get_jira_issue", return_value=parent_issue), \
+             patch.object(bp_module, "jira_api_request", return_value=jql_result):
+            assert bp_module.find_existing_linked_issue("SCYLLADB-100", "2025.4") is None
+
     def test_not_found(self, bp_module):
         parent_issue = {"fields": {"subtasks": []}}
         with patch.object(bp_module, "get_jira_issue", return_value=parent_issue), \

--- a/.github/tests/test_jira_functions.py
+++ b/.github/tests/test_jira_functions.py
@@ -645,3 +645,73 @@ class TestGetParentKeyIfSubtaskErrors:
         # Pass something that will cause an exception during processing
         result = bp_module.get_parent_key_if_subtask("not-a-dict")
         assert result is None
+
+
+class TestTeamInheritance:
+    """Backport issues are standalone linked issues, not sub-tasks, so they only end up
+    in team-based filters if the Team field is copied from the issue being backported.
+    """
+
+    TEAM = "f9cc1fd6-beaf-40ee-b7a1-0b51f09038d9"
+
+    def test_get_issue_team_id_from_object(self, bp_module):
+        issue = {"fields": {bp_module.JIRA_TEAM_FIELD: {"id": self.TEAM, "name": "Release Engineering"}}}
+        assert bp_module.get_issue_team_id(issue) == self.TEAM
+
+    def test_get_issue_team_id_from_plain_string(self, bp_module):
+        issue = {"fields": {bp_module.JIRA_TEAM_FIELD: self.TEAM}}
+        assert bp_module.get_issue_team_id(issue) == self.TEAM
+
+    def test_get_issue_team_id_when_unset(self, bp_module):
+        assert bp_module.get_issue_team_id({"fields": {bp_module.JIRA_TEAM_FIELD: None}}) is None
+        assert bp_module.get_issue_team_id({"fields": {}}) is None
+        assert bp_module.get_issue_team_id({}) is None
+
+    def test_resolve_falls_back_to_grandparent_for_subtask(self, bp_module):
+        """A legacy sub-task parent may carry no Team of its own."""
+        subtask = {
+            "fields": {
+                "issuetype": {"subtask": True},
+                "parent": {"key": "SCYLLADB-1"},
+                bp_module.JIRA_TEAM_FIELD: None,
+            }
+        }
+        root = {"fields": {bp_module.JIRA_TEAM_FIELD: {"id": self.TEAM}}}
+        with patch.object(bp_module, "get_jira_issue", side_effect=[subtask, root]):
+            assert bp_module.resolve_parent_team_id("SCYLLADB-2") == self.TEAM
+
+    def test_resolve_returns_none_when_nothing_has_a_team(self, bp_module):
+        issue = {"fields": {"issuetype": {"subtask": False}, bp_module.JIRA_TEAM_FIELD: None}}
+        with patch.object(bp_module, "get_jira_issue", return_value=issue):
+            assert bp_module.resolve_parent_team_id("SCYLLADB-100") is None
+
+    def test_created_issue_inherits_team(self, bp_module):
+        with patch.object(bp_module, "find_existing_linked_issue", return_value=None), \
+             patch.object(bp_module, "resolve_parent_team_id", return_value=self.TEAM), \
+             patch.object(bp_module, "jira_api_request", return_value={"key": "SCYLLADB-999"}) as mock_api, \
+             patch.object(bp_module, "create_jira_issue_link", return_value=True):
+            bp_module.create_jira_linked_issue("SCYLLADB-100", "2025.4", "Fix bug")
+            call_data = mock_api.call_args[0][2]
+            assert call_data["fields"][bp_module.JIRA_TEAM_FIELD] == self.TEAM
+
+    def test_no_team_field_when_parent_has_none(self, bp_module):
+        with patch.object(bp_module, "find_existing_linked_issue", return_value=None), \
+             patch.object(bp_module, "resolve_parent_team_id", return_value=None), \
+             patch.object(bp_module, "jira_api_request", return_value={"key": "SCYLLADB-999"}) as mock_api, \
+             patch.object(bp_module, "create_jira_issue_link", return_value=True):
+            bp_module.create_jira_linked_issue("SCYLLADB-100", "2025.4", "Fix bug")
+            call_data = mock_api.call_args[0][2]
+            assert bp_module.JIRA_TEAM_FIELD not in call_data["fields"]
+
+    def test_retries_without_team_when_creation_rejected(self, bp_module):
+        """Projects that don't have Team on their create screen must still get a backport issue."""
+        with patch.object(bp_module, "find_existing_linked_issue", return_value=None), \
+             patch.object(bp_module, "resolve_parent_team_id", return_value=self.TEAM), \
+             patch.object(bp_module, "jira_api_request",
+                          side_effect=[None, {"key": "SCYLLADB-999"}]) as mock_api, \
+             patch.object(bp_module, "create_jira_issue_link", return_value=True):
+            result = bp_module.create_jira_linked_issue("SCYLLADB-100", "2025.4", "Fix bug")
+            assert result == "SCYLLADB-999"
+            assert mock_api.call_count == 2
+            retry_data = mock_api.call_args[0][2]
+            assert bp_module.JIRA_TEAM_FIELD not in retry_data["fields"]

--- a/.github/tests/test_jira_functions.py
+++ b/.github/tests/test_jira_functions.py
@@ -715,3 +715,97 @@ class TestTeamInheritance:
             assert mock_api.call_count == 2
             retry_data = mock_api.call_args[0][2]
             assert bp_module.JIRA_TEAM_FIELD not in retry_data["fields"]
+
+
+class TestFindActiveSprintId:
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self, bp_module):
+        bp_module._active_sprint_cache.clear()
+        yield
+        bp_module._active_sprint_cache.clear()
+
+    def test_returns_active_sprint_of_first_board(self, bp_module):
+        responses = [
+            {"values": [{"id": 608, "name": "RE board"}]},
+            {"values": [{"id": 2112, "name": "RE Sprint 26#10", "state": "active"}]},
+        ]
+        with patch.object(bp_module, "jira_api_request", side_effect=responses) as mock_api:
+            assert bp_module.find_active_sprint_id("RELENG") == 2112
+            assert mock_api.call_args_list[0].kwargs["api_base"] == "agile/1.0"
+
+    def test_skips_board_without_active_sprint(self, bp_module):
+        """A kanban board answers with an error; keep looking at the other boards."""
+        responses = [
+            {"values": [{"id": 1}, {"id": 2}]},
+            None,
+            {"values": [{"id": 2112, "state": "active"}]},
+        ]
+        with patch.object(bp_module, "jira_api_request", side_effect=responses):
+            assert bp_module.find_active_sprint_id("RELENG") == 2112
+
+    def test_none_when_between_sprints(self, bp_module):
+        responses = [{"values": [{"id": 608}]}, {"values": []}]
+        with patch.object(bp_module, "jira_api_request", side_effect=responses):
+            assert bp_module.find_active_sprint_id("RELENG") is None
+
+    def test_none_when_project_has_no_board(self, bp_module):
+        with patch.object(bp_module, "jira_api_request", return_value={"values": []}):
+            assert bp_module.find_active_sprint_id("RELENG") is None
+
+    def test_result_is_cached_per_project(self, bp_module):
+        responses = [{"values": [{"id": 608}]}, {"values": [{"id": 2112, "state": "active"}]}]
+        with patch.object(bp_module, "jira_api_request", side_effect=responses) as mock_api:
+            assert bp_module.find_active_sprint_id("RELENG") == 2112
+            assert bp_module.find_active_sprint_id("RELENG") == 2112
+            assert mock_api.call_count == 2
+
+
+class TestScheduleBackportIssue:
+    def test_sets_sprint_and_zero_points(self, bp_module):
+        with patch.object(bp_module, "find_active_sprint_id", return_value=2112), \
+             patch.object(bp_module, "jira_api_request", return_value={}) as mock_api:
+            assert bp_module.schedule_backport_issue("RELENG-800") is True
+            method, endpoint, data = mock_api.call_args[0]
+            assert (method, endpoint) == ("PUT", "issue/RELENG-800")
+            assert data["fields"][bp_module.JIRA_SPRINT_FIELD] == 2112
+            assert data["fields"][bp_module.JIRA_STORY_POINTS_FIELD] == 0
+
+    def test_sets_points_even_without_an_active_sprint(self, bp_module):
+        with patch.object(bp_module, "find_active_sprint_id", return_value=None), \
+             patch.object(bp_module, "jira_api_request", return_value={}) as mock_api:
+            assert bp_module.schedule_backport_issue("RELENG-800") is True
+            data = mock_api.call_args[0][2]
+            assert data["fields"][bp_module.JIRA_STORY_POINTS_FIELD] == 0
+            assert bp_module.JIRA_SPRINT_FIELD not in data["fields"]
+
+    def test_retries_with_sprint_id_as_list(self, bp_module):
+        with patch.object(bp_module, "find_active_sprint_id", return_value=2112), \
+             patch.object(bp_module, "jira_api_request", side_effect=[None, {}]) as mock_api:
+            assert bp_module.schedule_backport_issue("RELENG-800") is True
+            assert mock_api.call_args[0][2]["fields"][bp_module.JIRA_SPRINT_FIELD] == [2112]
+
+    def test_failure_is_reported_not_raised(self, bp_module):
+        with patch.object(bp_module, "find_active_sprint_id", return_value=None), \
+             patch.object(bp_module, "jira_api_request", return_value=None):
+            assert bp_module.schedule_backport_issue("RELENG-800") is False
+
+
+class TestScheduleBackportIssues:
+    def test_schedules_each_backport_issue(self, bp_module):
+        mapping = {"RELENG-785": "RELENG-800", "SCYLLADB-1": "SCYLLADB-2"}
+        with patch.object(bp_module, "schedule_backport_issue") as mock_sched:
+            bp_module.schedule_backport_issues(mapping)
+            assert {c[0][0] for c in mock_sched.call_args_list} == {"RELENG-800", "SCYLLADB-2"}
+
+    def test_skips_parent_key_fallback(self, bp_module):
+        """When no backport issue was resolved the mapping points at the parent -- the
+        parent's own sprint and estimate must be left alone."""
+        with patch.object(bp_module, "schedule_backport_issue") as mock_sched:
+            bp_module.schedule_backport_issues({"RELENG-785": "RELENG-785"})
+            mock_sched.assert_not_called()
+
+    def test_handles_empty_mapping(self, bp_module):
+        with patch.object(bp_module, "schedule_backport_issue") as mock_sched:
+            bp_module.schedule_backport_issues(None)
+            bp_module.schedule_backport_issues({})
+            mock_sched.assert_not_called()

--- a/.github/tests/test_main_entry.py
+++ b/.github/tests/test_main_entry.py
@@ -137,6 +137,53 @@ class TestMainDispatch:
             bp_module.main()
             mock_chain.assert_called_once_with(repo, merged_pr, "scylladb/scylladb")
 
+    def test_chain_backport_waits_for_promotion_on_gating_branch(self, bp_module, make_pr, make_repo):
+        """A backport PR merged into next-X.Y is not promoted yet. Continuing the chain
+        now would backport an unreleased commit, so the chain must wait for the
+        'promoted-to-branch-X.Y' label (added by the push to branch-X.Y)."""
+        repo = make_repo()
+        merged_pr = make_pr(number=6551, merged=True, base_ref="next-2026.3",
+                            labels=["backport/2026.2"])
+        repo.get_pull.return_value = merged_pr
+
+        test_args = [
+            "auto-backport-jira.py",
+            "--repo", "scylladb/scylla-pkg",
+            "--base-branch", "refs/heads/next-2026.3",
+            "--chain-backport",
+            "--merged-pr", "6551"
+        ]
+
+        with patch.object(sys, "argv", test_args), \
+             patch.object(bp_module, "Github") as mock_gh, \
+             patch.object(bp_module, "process_chain_backport") as mock_chain:
+            mock_gh.return_value.get_repo.return_value = repo
+            bp_module.main()
+            mock_chain.assert_not_called()
+
+    def test_chain_backport_continues_once_promoted(self, bp_module, make_pr, make_repo):
+        """Once the commit reaches branch-X.Y the PR carries 'promoted-to-branch-X.Y',
+        so the chain may continue."""
+        repo = make_repo()
+        merged_pr = make_pr(number=6551, merged=True, base_ref="next-2026.3",
+                            labels=["backport/2026.2", "promoted-to-branch-2026.3"])
+        repo.get_pull.return_value = merged_pr
+
+        test_args = [
+            "auto-backport-jira.py",
+            "--repo", "scylladb/scylla-pkg",
+            "--base-branch", "refs/heads/next-2026.3",
+            "--chain-backport",
+            "--merged-pr", "6551"
+        ]
+
+        with patch.object(sys, "argv", test_args), \
+             patch.object(bp_module, "Github") as mock_gh, \
+             patch.object(bp_module, "process_chain_backport") as mock_chain:
+            mock_gh.return_value.get_repo.return_value = repo
+            bp_module.main()
+            mock_chain.assert_called_once_with(repo, merged_pr, "scylladb/scylla-pkg")
+
     def test_chain_backport_skips_unmerged_pr(self, bp_module, make_pr, make_repo):
         repo = make_repo()
         unmerged_pr = make_pr(number=456, merged=False)


### PR DESCRIPTION
Five independent fixes to the backport automation, four of them regressions surfaced by the chain of scylladb/scylla-pkg#6545 → #6551 → #6553. Each commit stands on its own and the test suite is green at every one of them.

**1. [`36b6e4a`](https://github.com/scylladb/github-automation/commit/36b6e4a263453f9cd01d372a1265b77680e05b7b) — auto-backport-jira: request summary field in the Jira JQL search**

**2. [`e2db16d`](https://github.com/scylladb/github-automation/commit/e2db16d3d0fd6fd8aadff0321879d9ac5e842ba8) — auto-backport-jira: point a chained backport at the PR it was picked from**

**3. [`8ec1465`](https://github.com/scylladb/github-automation/commit/8ec14659dd47ebd8ecefd3824c8c388ac3042821) — auto-backport-jira: wait for promotion before continuing the backport chain**

**4. [`b9e65c7`](https://github.com/scylladb/github-automation/commit/b9e65c710fc87acf3f54d09799aa8efd4b83f41f) — auto-backport-jira: inherit the Team field in backport issues**

Fixes: RELENG-786

**5. [`084df9f`](https://github.com/scylladb/github-automation/commit/084df9f97f71d6998d93e682b6ef3120c3450798) — auto-backport-jira: schedule backport issues when their PR is opened**

### Testing

`make test` — 444 passed. Also run against each commit individually: 413 / 413 / 422 / 430 / 444.
