### PR TITLE
PM-334: update non-epic GH-Jira sync automation for the new statuses

### DIFF
--- a/scripts/jira_sync_logic.py
+++ b/scripts/jira_sync_logic.py
@@ -15,6 +15,8 @@ import sys
 import argparse
 
 from jira_sync_modules import (
+    MERGED_STATUS_NAME,
+    MERGED_TRANSITION_ID,
     extract_jira_keys,
     add_label_to_jira_issue,
     extract_jira_issue_details,
@@ -58,9 +60,8 @@ def manage_labeled_gh_event(
       3.  if label is status/release_blocker  -> also add P0
       4.  extract_jira_issue_details
       5.  apply_jira_labels_to_pr
-      6.  if label is status/merge_candidate  -> transition to Ready for Merge
-      7.  if label starts with promoted-to-:
-            a. add comment  b. transition to Done
+      6.  if label starts with promoted-to-:
+            a. add comment  b. transition to Merged
     """
     print("=" * 60)
     print(" manage_labeled_gh_event  input parameters")
@@ -136,18 +137,9 @@ def manage_labeled_gh_event(
         pr_number, labels_csv, csv_content, triggering_label, owner_repo, gh_token,
     )
 
-    # --- Step 6: status/merge_candidate -> Ready for Merge ---
+    # --- Step 6: promoted-to-* label ---
     print("\n" + "=" * 60)
-    print(" Step 6 / jira_status_transition -> Ready for Merge")
-    print("=" * 60)
-    if triggering_label == "status/merge_candidate":
-        jira_status_transition(csv_content, "Ready for Merge", "131", jira_auth)
-    else:
-        print(f"SKIPPED: triggering_label is '{triggering_label}', not 'status/merge_candidate'")
-
-    # --- Step 7: promoted-to-* label ---
-    print("\n" + "=" * 60)
-    print(" Step 7a / add_comment_to_jira (promoted-to-*)")
+    print(" Step 6a / add_comment_to_jira (promoted-to-*)")
     print("=" * 60)
     if triggering_label.startswith("promoted-to-"):
         pr_url = f"https://github.com/{owner_repo}/pull/{pr_number}"
@@ -163,10 +155,10 @@ def manage_labeled_gh_event(
               f" (requires label starting with 'promoted-to-')")
 
     print("\n" + "=" * 60)
-    print(" Step 7b / jira_status_transition -> Done")
+    print(f" Step 6b / jira_status_transition -> {MERGED_STATUS_NAME}")
     print("=" * 60)
     if triggering_label.startswith("promoted-to-"):
-        jira_status_transition(csv_content, "Done", "141", jira_auth)
+        jira_status_transition(csv_content, MERGED_STATUS_NAME, MERGED_TRANSITION_ID, jira_auth)
     else:
         print(f"SKIPPED: triggering_label is '{triggering_label}'"
               f" (requires label starting with 'promoted-to-')")
@@ -356,7 +348,7 @@ def manage_closed_gh_event(
       2.  extract_jira_issue_details
       3.  apply_jira_labels_to_pr
       4.  add_comment_to_jira (merged: "Closed via PR merge"; not merged: "PR closed without merge")
-      5.  if merged: jira_status_transition -> "Done" (id 141)
+      5.  if merged: jira_status_transition -> "Merged" (id 10575)
     """
     print("=" * 60)
     print(" manage_closed_gh_event  input parameters")
@@ -403,16 +395,16 @@ def manage_closed_gh_event(
     )
 
     # --- Step 4: add "PR closed" comment ---
-    # Skip comment for issues already in a Done/closed state (PM-315).
+    # Skip comment for issues already in a closed state (Merged/Done/...) (PM-315).
     print("\n" + "=" * 60)
     print(" Step 4 / add_comment_to_jira (PR closed)")
     print("=" * 60)
     done_keys = get_done_issue_keys(csv_content)
     commentable_keys = [k for k in keys if k not in done_keys]
     if done_keys:
-        print(f"Skipping 'PR closed' comment for issues already in Done state: {sorted(done_keys)}")
+        print(f"Skipping 'PR closed' comment for issues already in a closed state: {sorted(done_keys)}")
     if not commentable_keys:
-        print("All linked issues are already in a Done state. Skipping comment.")
+        print("All linked issues are already in a closed state. Skipping comment.")
     else:
         commentable_keys_json = json.dumps(commentable_keys)
         pr_url = f"https://github.com/{owner_repo}/pull/{pr_number}"
@@ -433,12 +425,12 @@ def manage_closed_gh_event(
                 link_url=pr_url,
             )
 
-    # --- Step 5: transition to Done (merged PRs only) ---
+    # --- Step 5: transition to Merged (merged PRs only) ---
     print("\n" + "=" * 60)
-    print(" Step 5 / jira_status_transition -> Done")
+    print(f" Step 5 / jira_status_transition -> {MERGED_STATUS_NAME}")
     print("=" * 60)
     if pr_merged:
-        jira_status_transition(csv_content, "Done", "141", jira_auth)
+        jira_status_transition(csv_content, MERGED_STATUS_NAME, MERGED_TRANSITION_ID, jira_auth)
     else:
         print("SKIPPED: PR was closed without merge")
 
@@ -772,9 +764,6 @@ def debug_sync_context():
     print(f"jira-keys-json='{jira_keys_json}'")
     print(f"triggering-label='{label}'")
     print(f"repository='{repository}'")
-
-    if label == 'status/merge_candidate':
-        print("Try to transition Jira issue to 'Ready For Merge'")
 
     if label.startswith('promoted-to-'):
         print(f"Try to close Jira issue ({label} label added)")

--- a/scripts/jira_sync_modules.py
+++ b/scripts/jira_sync_modules.py
@@ -46,6 +46,16 @@ JIRA_BASE_URL = "https://scylladb.atlassian.net"
 SCYLLA_COMPONENTS_FIELD = "customfield_10321"
 SYMPTOM_FIELD = "customfield_11120"
 
+# Terminal status a merged PR moves its linked issues to.
+# Replaces the former "Done" (id 141) target (PM-334).
+MERGED_STATUS_NAME = "Merged"
+MERGED_TRANSITION_ID = "10575"
+
+# Jira issue types that are excluded from the GitHub sync entirely (PM-334).
+# Epics are planning containers managed by hand, so PR events must not
+# label them, transition them, or copy their fields onto the PR.
+_EXCLUDED_ISSUE_TYPES = {"epic"}
+
 # Regex: any JIRA-style key (PROJECT-123) in any text
 _JIRA_KEY_RE = re.compile(r'[A-Za-z]+-[0-9]+')
 
@@ -104,6 +114,41 @@ def _fetch_jira_project_keys(jira_auth: str) -> set[str]:
     except (HTTPError, URLError) as exc:
         print(f"Warning: Jira project lookup failed: {exc}")
         return set()
+
+
+def _filter_out_excluded_issue_types(keys: list[str], jira_auth: str) -> list[str]:
+    """Drop issues whose Jira issue type is excluded from the sync (PM-334).
+
+    Currently this removes Epics: they are planning containers that must not be
+    touched by PR-driven automation.  Keys whose type cannot be resolved are
+    kept, so a transient Jira error never silently disables the sync.
+    """
+    if not keys:
+        return keys
+
+    if not jira_auth:
+        print("Warning: jira_auth is not set; skipping issue-type filtering.")
+        return keys
+
+    kept: list[str] = []
+    for key in keys:
+        url = f"{JIRA_BASE_URL}/rest/api/3/issue/{key}?fields=issuetype"
+        resp = _jira_get(url, jira_auth)
+
+        if resp is None:
+            print(f"Warning: could not resolve issue type for {key}; keeping it.")
+            kept.append(key)
+            continue
+
+        issue_type = ((resp.get("fields") or {}).get("issuetype") or {}).get("name", "")
+        if issue_type.lower() in _EXCLUDED_ISSUE_TYPES:
+            print(f"Discarding {key} - issue type '{issue_type}' is excluded from sync.")
+            continue
+
+        print(f"Keeping {key} (issue type '{issue_type}').")
+        kept.append(key)
+
+    return kept
 
 
 def _fetch_commits(
@@ -166,7 +211,8 @@ def extract_jira_keys(
     1. Extract candidate JIRA keys from the PR body and commit messages.
     2. Accept keys whose project prefix is in the hard-coded set.
     3. For remaining keys, query the Jira API and accept valid prefixes.
-    4. Return a sorted, deduplicated list (or ["__NO_KEYS_FOUND__"]).
+    4. Discard issue types excluded from the sync, such as Epics (PM-334).
+    5. Return a sorted, deduplicated list (or ["__NO_KEYS_FOUND__"]).
 
     When owner_repo, pr_number, and gh_token are provided the function
     also fetches the PR's commit messages from the GitHub API and scans
@@ -253,7 +299,13 @@ def extract_jira_keys(
         print("No valid Jira keys found after validation")
         return ["__NO_KEYS_FOUND__"]
 
-    result = sorted(set(accepted))
+    # --- Pass 3: discard issue types the automation must not touch (PM-334) ---
+    result = _filter_out_excluded_issue_types(sorted(set(accepted)), jira_auth)
+
+    if not result:
+        print("All Jira keys were discarded by issue type (e.g. Epics)")
+        return ["__NO_KEYS_FOUND__"]
+
     print("Final Jira keys:")
     for key in result:
         print(f"  {key}")
@@ -955,8 +1007,10 @@ def apply_jira_labels_to_pr(
 # jira_status_transition
 # ---------------------------------------------------------------------------
 
-_WORKING_STATES = {"in progress", "in review", "ready for merge"}
-_CLOSED_STATES = {"done", "won't fix", "duplicate"}
+# "Ready for Merge" was dropped from the workflow (PM-334).
+_WORKING_STATES = {"in progress", "in review"}
+# "Done" is kept so issues closed before the rename are still recognised.
+_CLOSED_STATES = {"merged", "done", "won't fix", "duplicate"}
 
 
 def _jira_post(url: str, payload: dict, jira_auth: str) -> tuple[int, str]:
@@ -1109,9 +1163,6 @@ def jira_status_transition(
         # Guard: do not regress issues that are further along in the workflow
         _FORBIDDEN_TRANSITIONS = {
             ('in review', 'in progress'),
-            ('ready for merge', 'in progress'),
-            ('ready for merge', 'in review'),
-            ('done', 'done'),
         }
         if (current_status.lower(), target_lower) in _FORBIDDEN_TRANSITIONS:
             print(f"SKIP {key}: refusing to move from '{current_status}' to '{transition_name}'")

--- a/scripts/jira_sync_modules.py
+++ b/scripts/jira_sync_modules.py
@@ -1163,6 +1163,7 @@ def jira_status_transition(
         # Guard: do not regress issues that are further along in the workflow
         _FORBIDDEN_TRANSITIONS = {
             ('in review', 'in progress'),
+            ('merged', 'merged'),
         }
         if (current_status.lower(), target_lower) in _FORBIDDEN_TRANSITIONS:
             print(f"SKIP {key}: refusing to move from '{current_status}' to '{transition_name}'")


### PR DESCRIPTION
Updates the non-epic GH↔Jira sync automation for the new Jira statuses.

Fixes PM-334

## Changes

### 1. Remove "Ready for Merge"

The status no longer exists, so the automation must stop targeting it.

- `manage_labeled_gh_event`: dropped the `status/merge_candidate` → *Ready for Merge* (id 131) step entirely; the remaining `promoted-to-*` steps are renumbered 7a/7b → 6a/6b.
- `debug_sync_context`: dropped the "Try to transition Jira issue to 'Ready For Merge'" hint.
- `_WORKING_STATES`: removed `"ready for merge"`.
- `_FORBIDDEN_TRANSITIONS`: removed the two `ready for merge` regression guards and the `('done', 'done')` entry, and added `('merged', 'merged')` as an explicit guard against re-transitioning an issue that is already *Merged*.

  Note that `('merged', 'merged')` is belt-and-braces rather than load-bearing: `_plan_transitions` sorts an issue whose status equals the target into `already_ok`, and any status in `_CLOSED_STATES` (which now includes `"merged"`) into `done_issues` — so neither reaches the transition loop. That is the same reasoning under which `('done', 'done')` was dropped. Keeping the entry costs nothing and documents the intent if that routing ever changes.

Note that `status/merge_candidate` is still added to the Jira issue as a plain label by Step 2 — only the status transition is gone.

### 2. "Done" → "Merged" (id 10575)

- New constants in `jira_sync_modules.py`, so the target lives in one place:
  ```python
  MERGED_STATUS_NAME = "Merged"
  MERGED_TRANSITION_ID = "10575"
  ```
- Both callers now use them: `manage_closed_gh_event` (merged PRs) and `manage_labeled_gh_event` (`promoted-to-*` labels).
- `_CLOSED_STATES` gained `"merged"`. This keeps the two existing behaviours working for the new status: the due date is stamped on close, and the "PR closed" comment is skipped for issues that are already resolved (PM-315).
- `"done"` is deliberately **kept** in `_CLOSED_STATES` — issues closed before the rename still report `Done`, and dropping it would make the automation re-comment on and try to re-transition them.

### 3. Discard the automation for epics

Filtering happens in `extract_jira_keys`, which every orchestrator (opened / review / labeled / unlabeled / closed) calls as its first step — so one filter covers all five paths, and an Epic-only PR exits at the existing `__NO_KEYS_FOUND__` short-circuit before any write happens.

```python
_EXCLUDED_ISSUE_TYPES = {"epic"}
```

A key whose issue type can't be resolved (Jira error / 404) is **kept** rather than dropped, so a transient Jira outage degrades to today's behaviour instead of silently disabling the sync.

Cost: one extra `GET /issue/{key}?fields=issuetype` per linked key, which is the same request shape already used by `extract_jira_issue_details`.

## Testing

Not executed — no Python interpreter available on the machine this was authored from, and the repo has no test suite or CI to run against. The changes were reviewed by hand; the risk is concentrated in the new `_filter_out_excluded_issue_types` helper and the `MERGED_TRANSITION_ID` value.

Worth confirming on `automation-staging-branch` before this goes to production:

1. Transition id `10575` is the correct *Merged* transition for the target workflow, and is reachable from `In Progress` / `In Review`.
2. A PR with `Fixes <EPIC-KEY>` produces `All Jira keys were discarded by issue type (e.g. Epics)` and makes no Jira writes.
3. A PR with `Fixes <BUG-KEY>` still labels, comments and transitions as before.
4. A merged PR lands its issue in *Merged* with the due date set.

## Out of scope

`.github/workflows/jira_transition.yml` still contains the legacy shell implementation with `WORKING_STATES=(... "ready for merge")` and `CLOSED_STATES=("done" "won't fix")`. It is superseded by these scripts and PM-334 scopes the change to `scripts/`, so it is untouched here — but it should be updated or deleted if anything still calls it.
