### PR TITLE
PM-334: fix MERGED_TRANSITION_ID - transition id is 7, not status id 10575

### DIFF
--- a/scripts/jira_sync_logic.py
+++ b/scripts/jira_sync_logic.py
@@ -348,7 +348,7 @@ def manage_closed_gh_event(
       2.  extract_jira_issue_details
       3.  apply_jira_labels_to_pr
       4.  add_comment_to_jira (merged: "Closed via PR merge"; not merged: "PR closed without merge")
-      5.  if merged: jira_status_transition -> "Merged" (id 10575)
+      5.  if merged: jira_status_transition -> "Merged" (transition id 7)
     """
     print("=" * 60)
     print(" manage_closed_gh_event  input parameters")

--- a/scripts/jira_sync_modules.py
+++ b/scripts/jira_sync_modules.py
@@ -47,9 +47,14 @@ SCYLLA_COMPONENTS_FIELD = "customfield_10321"
 SYMPTOM_FIELD = "customfield_11120"
 
 # Terminal status a merged PR moves its linked issues to.
-# Replaces the former "Done" (id 141) target (PM-334).
+# Replaces the former "Done" (transition id 141) target (PM-334).
+#
+# This is the *transition* id, not the status id: jira_status_transition POSTs
+# {"transition": {"id": MERGED_TRANSITION_ID}} to /issue/{key}/transitions.
+# Transition 7 leads to the "Merged" status, whose own id is 10575 - passing
+# the status id here makes Jira reject the request with a 400.
 MERGED_STATUS_NAME = "Merged"
-MERGED_TRANSITION_ID = "10575"
+MERGED_TRANSITION_ID = "7"
 
 # Jira issue types that are excluded from the GitHub sync entirely (PM-334).
 # Epics are planning containers managed by hand, so PR events must not


### PR DESCRIPTION
Follow-up to #210 (PM-334).

`MERGED_TRANSITION_ID` was set to `"10575"`, which is the id of the **Merged status**, not the id
of the **transition** that leads to it.

`jira_status_transition` POSTs the value straight to the transitions endpoint:

```python
url = f"{JIRA_BASE_URL}/rest/api/3/issue/{key}/transitions"
payload = {"transition": {"id": transition_id}}
```

`GET /rest/api/3/issue/{key}/transitions` on the STAG project returns (identical for `Bug` and
`Task`):

| Transition ID | Name | Target status (status ID) |
|---|---|---|
| 111 | In Progress From All | In Progress (3) |
| 121 | In Review From All | In Review (10007) |
| 141 | Done From All | Done (10009) |
| **7** | **Merged** | **Merged (10575)** |

So the correct value is `"7"`. This matches the shape of the value it replaced — the old `Done`
target used transition id `141`, not status id `10009`.

## Impact

Both call sites were affected: `manage_closed_gh_event` (merged PRs) and
`manage_labeled_gh_event` (`promoted-to-*` labels). Jira rejects an unknown transition id with a
400, and `jira_status_transition` logs `FAIL <KEY> (400)` and continues rather than raising — so
the symptom is silent: merged PRs and `promoted-to-*` labels leave their linked issues in
whatever status they were already in, with only a `FAIL` line in the workflow log.

## Changes

- `scripts/jira_sync_modules.py` — `MERGED_TRANSITION_ID = "7"`, plus a comment explaining the
  transition-id / status-id distinction so the same mistake isn't reintroduced.
- `scripts/jira_sync_logic.py` — corrected the stale `-> "Merged" (id 10575)` reference in
  `manage_closed_gh_event`'s docstring.

No behavioural change beyond the id itself.

## Testing

`python -m py_compile` passes on both files. The transition table above was read from the live
Jira API rather than inferred.

Not executed end-to-end from here. The staging suite in scylladb/staging#247 covers this
directly — its steps 11 and 13 assert that `promoted-to-master` and a PR merge land the issue in
*Merged*, and they should pass once this is on `automation-staging-branch`.

One thing worth confirming before this is promoted beyond staging: transition `7` was verified in
the **STAG** project. The id is hardcoded and the automation runs across several Jira projects, so
it's worth checking the production workflows use the same id.
