### PR TITLE
jira_sync: re-check the Fixes reference when a PR body changes

### DIFF
--- a/.github/tests/test_enforce_backport_fixes.py
+++ b/.github/tests/test_enforce_backport_fixes.py
@@ -211,3 +211,68 @@ def test_does_not_comment_twice(monkeypatch):
     assert result is True
     assert rec.posted_comments() == []  # comment already present; not re-posted
     assert "backport%2F2025.4" in rec.deleted_labels()  # label still removed
+
+
+# ---------------------------------------------------------------------------
+# enforce_backport_fixes_on_body_change (RELENG-81)
+# ---------------------------------------------------------------------------
+
+def test_body_change_without_backport_label_is_a_noop(monkeypatch):
+    """A PR with no backport/<release> label is never asked for a Fixes: reference."""
+    rec = _GhRecorder(labels_json='[{"name": "backport/none"}, {"name": "area/build"}]')
+    monkeypatch.setattr(jsm, "_gh_api", rec)
+    monkeypatch.setattr(jsm, "extract_jira_keys", lambda *a, **k: pytest.fail("should not validate"))
+
+    result = jsm.enforce_backport_fixes_on_body_change(
+        "title", "no reference", 7, "scylladb/scylladb", "tok", "user:pass",
+    )
+    assert result is False
+    assert rec.posted_comments() == []
+    assert rec.deleted_labels() == []
+
+
+def test_body_change_with_valid_reference_is_allowed(monkeypatch):
+    rec = _GhRecorder(labels_json='[{"name": "backport/2025.4"}]')
+    monkeypatch.setattr(jsm, "_gh_api", rec)
+    monkeypatch.setattr(jsm, "extract_jira_keys", lambda *a, **k: ["SCYLLADB-123"])
+    monkeypatch.setattr(jsm, "_jira_issue_exists", lambda key, auth: True)
+
+    result = jsm.enforce_backport_fixes_on_body_change(
+        "title", "Fixes: SCYLLADB-123", 7, "scylladb/scylladb", "tok", "user:pass",
+    )
+    assert result is False
+    assert rec.deleted_labels() == []
+
+
+def test_body_edited_to_drop_reference_is_enforced(monkeypatch):
+    """The RELENG-81 gap: label added while valid, reference later edited away."""
+    rec = _GhRecorder(
+        pr_json='{"user": {"login": "alice"}, "assignees": []}',
+        labels_json='[{"name": "backport/2025.4"}, {"name": "P1"}]',
+    )
+    monkeypatch.setattr(jsm, "_gh_api", rec)
+    monkeypatch.setattr(jsm, "extract_jira_keys", lambda *a, **k: ["__NO_KEYS_FOUND__"])
+
+    result = jsm.enforce_backport_fixes_on_body_change(
+        "title", "reference removed", 7, "scylladb/scylladb", "tok", "user:pass",
+    )
+    assert result is True
+    assert len(rec.posted_comments()) == 1
+    assert "backport%2F2025.4" in rec.deleted_labels()
+    assert all("P1" not in d for d in rec.deleted_labels())
+
+
+def test_body_change_label_lookup_failure_fails_open(monkeypatch):
+    """If the label list can't be read, do nothing rather than penalise the PR."""
+    def failing_gh_api(method, url, gh_token, payload=None):
+        if method == "GET" and url.endswith("/labels"):
+            return 503, "service unavailable"
+        pytest.fail("no further calls expected")
+
+    monkeypatch.setattr(jsm, "_gh_api", failing_gh_api)
+    monkeypatch.setattr(jsm, "extract_jira_keys", lambda *a, **k: pytest.fail("should not validate"))
+
+    result = jsm.enforce_backport_fixes_on_body_change(
+        "title", "no reference", 7, "scylladb/scylladb", "tok", "user:pass",
+    )
+    assert result is False

--- a/scripts/jira_sync_logic.py
+++ b/scripts/jira_sync_logic.py
@@ -24,6 +24,7 @@ from jira_sync_modules import (
     remove_label_from_jira_issue,
     get_done_issue_keys,
     enforce_backport_fixes_reference,
+    enforce_backport_fixes_on_body_change,
     BACKPORT_LABEL_RE,
 )
 
@@ -545,6 +546,7 @@ def manage_opened_gh_event(
 
     Replicates the full job graph of main_jira_sync_pr_opened.yml:
 
+      0.  enforce_backport_fixes_on_body_change (RELENG-81)
       1.  extract_jira_keys
       2.  extract_jira_issue_details
       3.  apply_jira_labels_to_pr
@@ -559,6 +561,20 @@ def manage_opened_gh_event(
     print(f"  pr_event   = {os.environ.get('CALLER_ACTION', 'N/A')!r}")
     print(f"  pr_number  = {pr_number!r}")
     print(f"  owner_repo = {owner_repo!r}")
+
+    # --- Step 0: re-check the Fixes: reference while backport labels are set ---
+    # The 'labeled' handler enforces this when a backport label is added, but the
+    # body can be edited afterwards to drop the reference. Re-checking here (this
+    # handler serves both 'opened' and 'edited') catches that early instead of at
+    # backport time, after the merge. (RELENG-81)
+    print("\n" + "=" * 60)
+    print(" Step 0 / enforce_backport_fixes_on_body_change")
+    print("=" * 60)
+    if enforce_backport_fixes_on_body_change(
+        pr_title, pr_body, pr_number, owner_repo, gh_token, jira_auth,
+    ):
+        print("Backport label(s) removed. Please add to the PR body a link ('Fixes:') to a valid Jira issue and only then re-label the PR for backport.")
+        return
 
     # --- Step 1: extract jira keys ---
     print("\n" + "=" * 60)

--- a/scripts/jira_sync_modules.py
+++ b/scripts/jira_sync_modules.py
@@ -1472,3 +1472,49 @@ def enforce_backport_fixes_reference(
 
     _remove_backport_labels(owner_repo, pr_number, gh_token)
     return True
+
+
+def enforce_backport_fixes_on_body_change(
+    pr_title: str,
+    pr_body: str,
+    pr_number: int,
+    owner_repo: str,
+    gh_token: str,
+    jira_auth: str,
+) -> bool:
+    """Re-check the Fixes: reference when the PR body changes (RELENG-81).
+
+    enforce_backport_fixes_reference only runs on the 'labeled' event, so a PR
+    that was labelled while its body linked a valid issue keeps the label even
+    if the reference is later edited away - and the missing 'Fixes:' only
+    surfaces when the backport runs, long after the merge.
+
+    On 'opened'/'edited' this reads the backport/<release> labels currently on
+    the PR and, when there is at least one, applies the same enforcement. PRs
+    with no backport label (or only backport/none) are never asked for a Fixes:
+    reference, so plain feature or cleanup PRs are unaffected.
+
+    Returns True when an enforcement action was taken, False otherwise.
+    """
+    code, body = _gh_api(
+        "GET",
+        f"https://api.github.com/repos/{owner_repo}/issues/{pr_number}/labels",
+        gh_token,
+    )
+    if code != 200:
+        print(f"Warning: could not list labels on PR #{pr_number} (HTTP {code}); skipping Fixes: re-check.")
+        return False
+
+    backport_labels = [
+        name for name in (label.get("name", "") for label in json.loads(body))
+        if BACKPORT_LABEL_RE.match(name)
+    ]
+    if not backport_labels:
+        print(f"PR #{pr_number} carries no backport/<release> label; no Fixes: reference required.")
+        return False
+
+    print(f"PR #{pr_number} carries backport label(s) {backport_labels}; re-checking the Fixes: reference.")
+    return enforce_backport_fixes_reference(
+        pr_title, pr_body, pr_number, backport_labels[0],
+        owner_repo, gh_token, jira_auth,
+    )


### PR DESCRIPTION
## Summary
`enforce_backport_fixes_reference` (RELENG-175) only runs on the `labeled` event. A PR that was labelled while its body linked a valid issue therefore keeps the backport label even if the reference is later edited away, and the missing `Fixes:` surfaces only when the backport runs, after the merge — exactly the late, confusing failure RELENG-81 asks us to move to the beginning of the process.

- New `enforce_backport_fixes_on_body_change` reads the backport labels currently on the PR and, when at least one `backport/<release>` label is present, applies the existing enforcement (comment once, strip the backport labels).
- Wired as step 0 of `manage_opened_gh_event`, which serves both the `opened` and `edited` events. It has to run before step 1, because `extract_jira_keys` returns early precisely in the case we care about. `scylladb`'s `call_jira_sync.yml` already sends `edited`, so no workflow change is needed.
- PRs with no backport label, or only `backport/none`, are never asked for a `Fixes:` reference, so feature and cleanup PRs are unaffected. A failure to read the label list fails open.

## Testing
Four new cases in `test_enforce_backport_fixes.py`: no-label noop, valid reference allowed, reference edited away is enforced, label-lookup failure fails open. Full suite: 448 passed.

## Related PRs
- scylladb/scylladb#31044 — adds the same `Fixes:` requirement to the early `PR require backport label` job, covering `opened`/`labeled`/`synchronize`. Together the two close the whole window.

Fixes: RELENG-81