### PR TITLE
Change branch reference from staging to main

### DIFF
--- a/.github/workflows/main_pr_events_jira_sync.yml
+++ b/.github/workflows/main_pr_events_jira_sync.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: scylladb/github-automation
-          ref: automation-staging-branch
+          ref: main
 
       - name: Run Jira sync orchestrator
         env:


### PR DESCRIPTION
Fix a bug, where the automation Jira-GH sync was readying the code from the wrong branch.