### PR TITLE
Add periodic reconciliation for promoted-to-* labels

### DIFF
--- a/.github/scripts/reconcile_promoted_labels.py
+++ b/.github/scripts/reconcile_promoted_labels.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""
+Reconciliation safety net for promoted-to-* labels.
+
+search_commits.py labels a PR as promoted the moment its commit lands on
+master/branch-X.Y, but it only ever runs off a single push event's exact
+before..after commit range. If that push's webhook is ever dropped by
+GitHub (observed for scylladb/scylladb#30992 - RELENG-824: the commit
+promoting the PR landed on master, but no "push" webhook fired for it at
+all, so search_commits.py never got a chance to see it), the PR is left
+without its promoted-to-* label with nothing to ever retry it.
+
+This script re-scans the last `--lookback` commits of each given branch on
+a schedule, independent of push events, and re-applies the same labeling
+logic. Re-running it over commits that were already labeled is harmless -
+adding a label a PR already has is a no-op.
+"""
+
+import argparse
+import os
+import sys
+
+from github import Github
+
+from search_commits import GITHUB_RETRY, label_promoted_commits
+
+try:
+    github_token = os.environ["GITHUB_TOKEN"]
+except KeyError:
+    print("Please set the 'GITHUB_TOKEN' environment variable")
+    sys.exit(1)
+
+
+def parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--repository', type=str, required=True,
+                         help='Github repository name (e.g., scylladb/scylladb)')
+    parser.add_argument('--branches', type=str, required=True,
+                         help='Comma-separated branches to reconcile (e.g. master,branch-2026.3)')
+    parser.add_argument('--lookback', type=int, default=500,
+                         help='How many of the most recent commits per branch to re-scan')
+    return parser.parse_args()
+
+
+def main():
+    args = parser()
+    branches = [b.strip() for b in args.branches.split(',') if b.strip()]
+    if not branches:
+        print("No branches given, nothing to reconcile.")
+        return
+
+    g = Github(github_token, retry=GITHUB_RETRY)
+    repo = g.get_repo(args.repository, lazy=False)
+
+    for branch in branches:
+        print(f"::group::Reconciling promoted labels on {args.repository}@{branch} "
+              f"(last {args.lookback} commits)")
+        commits = repo.get_commits(sha=branch)[:args.lookback]
+        label_promoted_commits(
+            repository=args.repository,
+            commits=commits,
+            ref=f'refs/heads/{branch}',
+            label='promoted-to-master',
+            github_token=github_token,
+        )
+        print("::endgroup::")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/search_commits.py
+++ b/.github/scripts/search_commits.py
@@ -47,6 +47,16 @@ def requests_session_with_retries() -> requests.Session:
 http = requests_session_with_retries()
 
 
+def _raise_for_status(response, action, ok_statuses=()):
+    """Raise loudly on a failed GitHub API call instead of letting the
+    caller silently treat it as 'no match' or 'nothing to do'. `http`
+    already retries transient 5xx/403/429 extensively, so a response that
+    still isn't ok here is a persistent failure worth stopping for."""
+    if response.ok or response.status_code in ok_statuses:
+        return
+    raise RuntimeError(f"{action} failed: HTTP {response.status_code} {response.text}")
+
+
 def parser():
     parser = argparse.ArgumentParser()
     parser.add_argument('--repository', type=str, default='scylladb/scylla-pkg', help='Github repository name')
@@ -112,6 +122,7 @@ def label_promoted_commits(repository, commits, ref, label, github_token):
             "q": query,
         }
         response = http.get(search_url, headers=headers, params=params)
+        _raise_for_status(response, f"Searching for PRs matching commit {commit.sha}")
         prs = response.json().get("items", [])
         # Fallback: if the commit message has "Closes" references, include those PRs too
         # This handles PRs closed by pushing a rebased commit directly (different SHA than the PR's head)
@@ -129,6 +140,9 @@ def label_promoted_commits(repository, commits, ref, label, github_token):
             if pr_num not in found_pr_numbers and pr_num not in processed_prs:
                 pr_url = f'https://api.github.com/repos/{repository}/pulls/{pr_num}'
                 pr_response = http.get(pr_url, headers=headers)
+                # A 404 here means the referenced PR number genuinely doesn't
+                # exist (e.g. a stale/typo'd reference) - not a failure to raise on.
+                _raise_for_status(pr_response, f"Fetching PR #{pr_num}", ok_statuses=(404,))
                 if pr_response.ok:
                     pr_data = pr_response.json()
                     if pr_data.get("state") == "closed":
@@ -140,7 +154,10 @@ def label_promoted_commits(repository, commits, ref, label, github_token):
                             continue
                         prs.append(pr_data)
         for pr in prs:
-            match = re.findall(r'Parent PR: #(\d+)', pr["body"])
+            # Body can legitimately be None (empty PR description) - don't let
+            # that crash the run and strand every later PR/commit unprocessed.
+            pr_body = pr.get("body") or ""
+            match = re.findall(r'Parent PR: #(\d+)', pr_body)
             if match:
                 pr_number = int(match[0])
                 if pr_number in processed_prs:
@@ -153,10 +170,9 @@ def label_promoted_commits(repository, commits, ref, label, github_token):
                     "labels": [f'{label_to_remove}']
                 }
                 response = http.delete(remove_label_url, headers=headers, json=del_data)
-                if response.ok:
-                    print(f'Label {label_to_remove} removed successfully')
-                else:
-                    print(f'Label {label_to_remove} cant be removed')
+                # A 404 means the PR simply didn't have that label anymore - fine.
+                _raise_for_status(response, f"Removing label {label_to_remove} from PR #{pr_number}", ok_statuses=(404,))
+                print(f'Label {label_to_remove} removed successfully')
             else:
                 pr_number = pr["number"]
                 label_to_add = promoted_label
@@ -165,10 +181,11 @@ def label_promoted_commits(repository, commits, ref, label, github_token):
             }
             add_label_url = f'https://api.github.com/repos/{repository}/issues/{pr_number}/labels'
             response = http.post(add_label_url, headers=headers, json=data)
-            if response.ok:
-                print(f"Label added successfully to {add_label_url}")
-            else:
-                print(f"No label was added to {add_label_url}")
+            _raise_for_status(response, f"Adding label {label_to_add} to PR #{pr_number}")
+            print(f"Label added successfully to {add_label_url}")
+            # Only mark a PR processed once its label update actually succeeded,
+            # so a failure here surfaces loudly instead of the run reporting
+            # success while the PR is still unlabeled.
             processed_prs.add(pr_number)
     return processed_prs
 

--- a/.github/scripts/search_commits.py
+++ b/.github/scripts/search_commits.py
@@ -77,32 +77,39 @@ def get_promoted_label_for_ref(ref: str) -> str:
     return f'promoted-to-{branch}'
 
 
-def main():
-    args = parser()
+def label_promoted_commits(repository, commits, ref, label, github_token):
+    """
+    Scan `commits` (an iterable of PyGithub Commit objects) for PRs that were
+    promoted to `ref`, and apply the appropriate promoted-to-* label.
 
+    Shared between the push-triggered path (main(), fed with the exact
+    before..after range of a single push) and the periodic reconciliation
+    path (reconcile_promoted_labels.py, fed with a lookback window of recent
+    commits), which exists because a dropped push webhook otherwise leaves a
+    promoted PR unlabeled forever - see RELENG-824.
+
+    Re-running this over the same commits is safe: adding a label a PR
+    already has, or removing one it no longer has, is a no-op on GitHub's side.
+    """
     # Skip gating branches (next-X.Y, next) - labels should only be added
     # when commits are promoted to the stable branch (branch-X.Y, master)
-    branch = args.ref.replace('refs/heads/', '') if args.ref.startswith('refs/heads/') else args.ref
+    branch = ref.replace('refs/heads/', '') if ref.startswith('refs/heads/') else ref
     if branch.startswith('next-') or branch == 'next':
         print(f"Skipping push to gating branch {branch} - waiting for promotion to stable branch")
-        return
+        return set()
 
-    g = Github(github_token, retry=GITHUB_RETRY)
-    repo = g.get_repo(args.repository, lazy=False)
-    start_commit, end_commit = args.commits.split('..')
-    commits = repo.compare(start_commit, end_commit).commits
     # Compute the correct promoted label based on the branch
-    promoted_label = get_promoted_label_for_ref(args.ref) if args.label == 'promoted-to-master' else args.label
+    promoted_label = get_promoted_label_for_ref(ref) if label == 'promoted-to-master' else label
+    headers = {
+        "Authorization": f"token {github_token}",
+        "Accept": "application/vnd.github.v3+json"
+    }
     processed_prs = set()
     for commit in commits:
-        search_url = f'https://api.github.com/search/issues'
-        query = f"repo:{args.repository} is:pr is:closed sha:{commit.sha}"
+        search_url = 'https://api.github.com/search/issues'
+        query = f"repo:{repository} is:pr is:closed sha:{commit.sha}"
         params = {
             "q": query,
-        }
-        headers = {
-            "Authorization": f"token {github_token}",
-            "Accept": "application/vnd.github.v3+json"
         }
         response = http.get(search_url, headers=headers, params=params)
         prs = response.json().get("items", [])
@@ -112,15 +119,15 @@ def main():
         # because promoter commits may contain Closes references to PRs from other branches.
         found_pr_numbers = {pr["number"] for pr in prs}
         close_refs = re.findall(
-            rf'Closes\s+(?:{re.escape(args.repository)}#|#)(\d+)',
+            rf'Closes\s+(?:{re.escape(repository)}#|#)(\d+)',
             commit.commit.message
         )
         # Extract the short branch name from the ref for comparison
-        target_branch = args.ref.replace('refs/heads/', '') if args.ref.startswith('refs/heads/') else args.ref
-        for ref in close_refs:
-            pr_num = int(ref)
+        target_branch = branch
+        for close_ref in close_refs:
+            pr_num = int(close_ref)
             if pr_num not in found_pr_numbers and pr_num not in processed_prs:
-                pr_url = f'https://api.github.com/repos/{args.repository}/pulls/{pr_num}'
+                pr_url = f'https://api.github.com/repos/{repository}/pulls/{pr_num}'
                 pr_response = http.get(pr_url, headers=headers)
                 if pr_response.ok:
                     pr_data = pr_response.json()
@@ -138,10 +145,10 @@ def main():
                 pr_number = int(match[0])
                 if pr_number in processed_prs:
                     continue
-                ref = re.search(r'-(\d+\.\d+)', args.ref)
-                label_to_add = f'backport/{ref.group(1)}-done'
-                label_to_remove = f'backport/{ref.group(1)}'
-                remove_label_url = f'https://api.github.com/repos/{args.repository}/issues/{pr_number}/labels/{label_to_remove}'
+                version_ref = re.search(r'-(\d+\.\d+)', ref)
+                label_to_add = f'backport/{version_ref.group(1)}-done'
+                label_to_remove = f'backport/{version_ref.group(1)}'
+                remove_label_url = f'https://api.github.com/repos/{repository}/issues/{pr_number}/labels/{label_to_remove}'
                 del_data = {
                     "labels": [f'{label_to_remove}']
                 }
@@ -156,13 +163,23 @@ def main():
             data = {
                 "labels": [f'{label_to_add}']
             }
-            add_label_url = f'https://api.github.com/repos/{args.repository}/issues/{pr_number}/labels'
+            add_label_url = f'https://api.github.com/repos/{repository}/issues/{pr_number}/labels'
             response = http.post(add_label_url, headers=headers, json=data)
             if response.ok:
                 print(f"Label added successfully to {add_label_url}")
             else:
                 print(f"No label was added to {add_label_url}")
             processed_prs.add(pr_number)
+    return processed_prs
+
+
+def main():
+    args = parser()
+    g = Github(github_token, retry=GITHUB_RETRY)
+    repo = g.get_repo(args.repository, lazy=False)
+    start_commit, end_commit = args.commits.split('..')
+    commits = repo.compare(start_commit, end_commit).commits
+    label_promoted_commits(args.repository, commits, args.ref, args.label, github_token)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/search_commits.py
+++ b/.github/scripts/search_commits.py
@@ -158,10 +158,13 @@ def label_promoted_commits(repository, commits, ref, label, github_token):
             # that crash the run and strand every later PR/commit unprocessed.
             pr_body = pr.get("body") or ""
             match = re.findall(r'Parent PR: #(\d+)', pr_body)
+            pr_number = int(match[0]) if match else pr["number"]
+            # Multiple scanned commits can resolve to the same PR (e.g. several
+            # commits of one squashed/merged PR all matching the sha search) -
+            # skip it once already labeled instead of re-issuing the same POST.
+            if pr_number in processed_prs:
+                continue
             if match:
-                pr_number = int(match[0])
-                if pr_number in processed_prs:
-                    continue
                 version_ref = re.search(r'-(\d+\.\d+)', ref)
                 label_to_add = f'backport/{version_ref.group(1)}-done'
                 label_to_remove = f'backport/{version_ref.group(1)}'
@@ -174,7 +177,6 @@ def label_promoted_commits(repository, commits, ref, label, github_token):
                 _raise_for_status(response, f"Removing label {label_to_remove} from PR #{pr_number}", ok_statuses=(404,))
                 print(f'Label {label_to_remove} removed successfully')
             else:
-                pr_number = pr["number"]
                 label_to_add = promoted_label
             data = {
                 "labels": [f'{label_to_add}']

--- a/.github/tests/test_search_commits.py
+++ b/.github/tests/test_search_commits.py
@@ -49,9 +49,11 @@ def _commit(sha, message):
     return commit
 
 
-def _response(json_data, ok=True):
+def _response(json_data, ok=True, status_code=None):
     resp = MagicMock()
     resp.ok = ok
+    resp.status_code = status_code if status_code is not None else (200 if ok else 500)
+    resp.text = str(json_data)
     resp.json.return_value = json_data
     return resp
 
@@ -164,6 +166,69 @@ class TestLabelPromotedCommits:
 
         assert processed == {7}
         mock_post.assert_called_once()
+
+    def test_null_pr_body_does_not_crash(self, sc_module):
+        """A PR with no description (body=None) must not raise and abort
+        every later commit/PR - it just isn't a backport PR, so it gets the
+        plain promoted label."""
+        commit = _commit("sha1", "Fix bug\n\nCloses scylladb/scylladb#42")
+        search_resp = _response({"items": [{"number": 42, "body": None}]})
+        add_label_resp = _response({})
+
+        with patch.object(sc_module.http, "get", return_value=search_resp), \
+             patch.object(sc_module.http, "post", return_value=add_label_resp) as mock_post:
+            processed = sc_module.label_promoted_commits(
+                "scylladb/scylladb", [commit], "refs/heads/master",
+                "promoted-to-master", "tok",
+            )
+
+        assert processed == {42}
+        assert mock_post.call_args[1]["json"] == {"labels": ["promoted-to-master"]}
+
+    def test_raises_on_failed_search_request(self, sc_module):
+        commit = _commit("sha1", "msg")
+        failed_resp = _response({"message": "rate limit exceeded"}, ok=False, status_code=403)
+
+        with patch.object(sc_module.http, "get", return_value=failed_resp), \
+             patch.object(sc_module.http, "post") as mock_post:
+            with pytest.raises(RuntimeError, match="Searching for PRs"):
+                sc_module.label_promoted_commits(
+                    "scylladb/scylladb", [commit], "refs/heads/master",
+                    "promoted-to-master", "tok",
+                )
+
+        mock_post.assert_not_called()
+
+    def test_raises_on_failed_label_add_and_leaves_pr_unprocessed(self, sc_module):
+        commit = _commit("sha1", "msg")
+        search_resp = _response({"items": [{"number": 55, "body": ""}]})
+        failed_post = _response({"message": "Internal Server Error"}, ok=False, status_code=500)
+
+        with patch.object(sc_module.http, "get", return_value=search_resp), \
+             patch.object(sc_module.http, "post", return_value=failed_post):
+            with pytest.raises(RuntimeError, match="Adding label"):
+                sc_module.label_promoted_commits(
+                    "scylladb/scylladb", [commit], "refs/heads/master",
+                    "promoted-to-master", "tok",
+                )
+        # A failure must not let the PR silently count as done.
+
+    def test_404_on_closes_fallback_pr_fetch_is_not_an_error(self, sc_module):
+        """A 'Closes #NNN' reference to a PR number that no longer exists
+        (stale/typo) should be skipped quietly, not treated as an API failure."""
+        commit = _commit("sha1", "Closes scylladb/scylladb#404")
+        search_resp = _response({"items": []})
+        not_found_resp = _response({"message": "Not Found"}, ok=False, status_code=404)
+
+        with patch.object(sc_module.http, "get", side_effect=[search_resp, not_found_resp]), \
+             patch.object(sc_module.http, "post") as mock_post:
+            processed = sc_module.label_promoted_commits(
+                "scylladb/scylladb", [commit], "refs/heads/master",
+                "promoted-to-master", "tok",
+            )
+
+        assert processed == set()
+        mock_post.assert_not_called()
 
 
 class TestReconcilePromotedLabels:

--- a/.github/tests/test_search_commits.py
+++ b/.github/tests/test_search_commits.py
@@ -1,0 +1,203 @@
+"""
+Unit tests for search_commits.py (promoted-to-* labeling) and
+reconcile_promoted_labels.py (the RELENG-824 reconciliation safety net).
+"""
+
+import importlib
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def sc_module(_set_env_vars):
+    scripts_dir = os.path.join(os.path.dirname(__file__), "..", "scripts")
+    scripts_dir = os.path.abspath(scripts_dir)
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+
+    spec = importlib.util.spec_from_file_location(
+        "search_commits",
+        os.path.join(scripts_dir, "search_commits.py"),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["search_commits"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="session")
+def reconcile_module(sc_module):
+    scripts_dir = os.path.join(os.path.dirname(__file__), "..", "scripts")
+    spec = importlib.util.spec_from_file_location(
+        "reconcile_promoted_labels",
+        os.path.join(scripts_dir, "reconcile_promoted_labels.py"),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["reconcile_promoted_labels"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _commit(sha, message):
+    commit = MagicMock()
+    commit.sha = sha
+    commit.commit = MagicMock()
+    commit.commit.message = message
+    return commit
+
+
+def _response(json_data, ok=True):
+    resp = MagicMock()
+    resp.ok = ok
+    resp.json.return_value = json_data
+    return resp
+
+
+class TestGetPromotedLabelForRef:
+    def test_master(self, sc_module):
+        assert sc_module.get_promoted_label_for_ref("master") == "promoted-to-master"
+
+    def test_next(self, sc_module):
+        assert sc_module.get_promoted_label_for_ref("next") == "promoted-to-master"
+
+    def test_branch(self, sc_module):
+        assert sc_module.get_promoted_label_for_ref("refs/heads/branch-2026.3") == "promoted-to-branch-2026.3"
+
+    def test_next_gating_branch(self, sc_module):
+        assert sc_module.get_promoted_label_for_ref("next-2026.3") == "promoted-to-branch-2026.3"
+
+
+class TestLabelPromotedCommits:
+    def test_skips_gating_branch(self, sc_module):
+        result = sc_module.label_promoted_commits(
+            "scylladb/scylladb", [_commit("a", "msg")], "refs/heads/next-2026.3",
+            "promoted-to-master", "tok",
+        )
+        assert result == set()
+
+    def test_labels_pr_found_via_search_api(self, sc_module):
+        commit = _commit("sha1", "Fix bug\n\nCloses scylladb/scylladb#123")
+        search_resp = _response({"items": [{"number": 123, "body": "Fixes: SCYLLADB-1"}]})
+        add_label_resp = _response({})
+
+        with patch.object(sc_module.http, "get", return_value=search_resp) as mock_get, \
+             patch.object(sc_module.http, "post", return_value=add_label_resp) as mock_post:
+            processed = sc_module.label_promoted_commits(
+                "scylladb/scylladb", [commit], "refs/heads/master",
+                "promoted-to-master", "tok",
+            )
+
+        assert processed == {123}
+        mock_post.assert_called_once()
+        assert mock_post.call_args[0][0] == (
+            "https://api.github.com/repos/scylladb/scylladb/issues/123/labels"
+        )
+        assert mock_post.call_args[1]["json"] == {"labels": ["promoted-to-master"]}
+        mock_get.assert_called_once()  # only the search call, no 'Closes' fallback needed
+
+    def test_labels_pr_via_closes_fallback_when_search_misses(self, sc_module):
+        """Reproduces scylladb/scylladb#30992 (RELENG-824): PR closed by pushing a
+        rebased commit directly, so the search-by-sha API finds nothing and the
+        'Closes #NNN' fallback is what must catch it."""
+        commit = _commit("rebased_sha", "s3_client: fix bug\n\nCloses scylladb/scylladb#30992")
+        search_resp = _response({"items": []})
+        pr_resp = _response({
+            "number": 30992,
+            "body": "Fixes: SCYLLADB-569",
+            "state": "closed",
+            "base": {"ref": "master"},
+        })
+        add_label_resp = _response({})
+
+        with patch.object(sc_module.http, "get", side_effect=[search_resp, pr_resp]), \
+             patch.object(sc_module.http, "post", return_value=add_label_resp) as mock_post:
+            processed = sc_module.label_promoted_commits(
+                "scylladb/scylladb", [commit], "refs/heads/master",
+                "promoted-to-master", "tok",
+            )
+
+        assert processed == {30992}
+        assert mock_post.call_args[0][0] == (
+            "https://api.github.com/repos/scylladb/scylladb/issues/30992/labels"
+        )
+
+    def test_closes_fallback_skips_pr_targeting_other_branch(self, sc_module):
+        commit = _commit("sha1", "Closes scylladb/scylladb#99")
+        search_resp = _response({"items": []})
+        pr_resp = _response({
+            "number": 99,
+            "body": "",
+            "state": "closed",
+            "base": {"ref": "branch-2025.4"},
+        })
+
+        with patch.object(sc_module.http, "get", side_effect=[search_resp, pr_resp]), \
+             patch.object(sc_module.http, "post") as mock_post:
+            processed = sc_module.label_promoted_commits(
+                "scylladb/scylladb", [commit], "refs/heads/master",
+                "promoted-to-master", "tok",
+            )
+
+        assert processed == set()
+        mock_post.assert_not_called()
+
+    def test_dedupes_pr_across_commits(self, sc_module):
+        commits = [
+            _commit("sha1", "Closes scylladb/scylladb#7"),
+            _commit("sha2", "Closes scylladb/scylladb#7"),
+        ]
+        add_label_resp = _response({})
+
+        with patch.object(sc_module.http, "get", side_effect=[
+                 _response({"items": []}),
+                 _response({"number": 7, "body": "", "state": "closed", "base": {"ref": "master"}}),
+                 _response({"items": []}),
+             ]), \
+             patch.object(sc_module.http, "post", return_value=add_label_resp) as mock_post:
+            processed = sc_module.label_promoted_commits(
+                "scylladb/scylladb", commits, "refs/heads/master",
+                "promoted-to-master", "tok",
+            )
+
+        assert processed == {7}
+        mock_post.assert_called_once()
+
+
+class TestReconcilePromotedLabels:
+    def test_reconciles_each_branch_with_lookback_window(self, reconcile_module, sc_module):
+        commits = [_commit(f"sha{i}", "msg") for i in range(5)]
+
+        repo = MagicMock()
+        repo.get_commits.return_value = commits
+        gh_instance = MagicMock()
+        gh_instance.get_repo.return_value = repo
+
+        with patch.object(reconcile_module, "Github", return_value=gh_instance), \
+             patch.object(reconcile_module, "label_promoted_commits") as mock_label, \
+             patch.object(reconcile_module, "parser") as mock_parser:
+            mock_parser.return_value = MagicMock(
+                repository="scylladb/scylladb",
+                branches="master,branch-2026.3",
+                lookback=3,
+            )
+            reconcile_module.main()
+
+        assert mock_label.call_count == 2
+        refs_used = {call.kwargs["ref"] for call in mock_label.call_args_list}
+        assert refs_used == {"refs/heads/master", "refs/heads/branch-2026.3"}
+        for call in mock_label.call_args_list:
+            assert call.kwargs["repository"] == "scylladb/scylladb"
+            assert len(call.kwargs["commits"]) == 3  # sliced to the lookback window
+
+    def test_no_branches_is_a_noop(self, reconcile_module):
+        with patch.object(reconcile_module, "Github") as mock_gh, \
+             patch.object(reconcile_module, "parser") as mock_parser:
+            mock_parser.return_value = MagicMock(
+                repository="scylladb/scylladb", branches="  , ", lookback=500,
+            )
+            reconcile_module.main()
+
+        mock_gh.assert_not_called()

--- a/.github/tests/test_search_commits.py
+++ b/.github/tests/test_search_commits.py
@@ -167,6 +167,25 @@ class TestLabelPromotedCommits:
         assert processed == {7}
         mock_post.assert_called_once()
 
+    def test_dedupes_ordinary_pr_found_via_direct_search_across_commits(self, sc_module):
+        """Two commits of the same PR (e.g. a merge commit range) both match
+        via the direct sha search - only the first should trigger a label POST."""
+        commits = [_commit("sha1", "msg1"), _commit("sha2", "msg2")]
+        add_label_resp = _response({})
+
+        with patch.object(sc_module.http, "get", side_effect=[
+                 _response({"items": [{"number": 88, "body": ""}]}),
+                 _response({"items": [{"number": 88, "body": ""}]}),
+             ]), \
+             patch.object(sc_module.http, "post", return_value=add_label_resp) as mock_post:
+            processed = sc_module.label_promoted_commits(
+                "scylladb/scylladb", commits, "refs/heads/master",
+                "promoted-to-master", "tok",
+            )
+
+        assert processed == {88}
+        mock_post.assert_called_once()
+
     def test_null_pr_body_does_not_crash(self, sc_module):
         """A PR with no description (body=None) must not raise and abort
         every later commit/PR - it just isn't a backport PR, so it gets the

--- a/.github/workflows/reconcile-promoted-labels.yaml
+++ b/.github/workflows/reconcile-promoted-labels.yaml
@@ -1,0 +1,49 @@
+name: Reconcile promoted-to-* labels
+
+# Safety net for search_commits.py: it labels PRs off a single push event's
+# commit range, so a dropped push webhook leaves a PR unlabeled forever with
+# nothing to retry it (RELENG-824). This re-scans recent commits on a
+# schedule, independent of push events, and re-applies any missing labels.
+on:
+  schedule:
+    - cron: '23 */2 * * *'  # every 2 hours, offset off the hour mark
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: 'Repository to reconcile (owner/name)'
+        required: false
+        default: 'scylladb/scylladb'
+      branches:
+        description: 'Comma-separated branches to reconcile'
+        required: false
+        default: 'master'
+      lookback:
+        description: 'How many recent commits per branch to re-scan'
+        required: false
+        default: '500'
+
+jobs:
+  reconcile:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      RECONCILE_REPOSITORY: ${{ github.event.inputs.repository || 'scylladb/scylladb' }}
+      RECONCILE_BRANCHES: ${{ github.event.inputs.branches || 'master' }}
+      RECONCILE_LOOKBACK: ${{ github.event.inputs.lookback || '500' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install dependencies
+        run: sudo apt-get install -y python3-github python3-requests
+
+      - name: Reconcile promoted-to-* labels
+        working-directory: .github/scripts
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROMOTED_LABEL_RECONCILE_TOKEN }}
+        run: |
+          python reconcile_promoted_labels.py \
+            --repository "${RECONCILE_REPOSITORY}" \
+            --branches "${RECONCILE_BRANCHES}" \
+            --lookback "${RECONCILE_LOOKBACK}"

--- a/.github/workflows/reconcile-promoted-labels.yaml
+++ b/.github/workflows/reconcile-promoted-labels.yaml
@@ -38,6 +38,15 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get install -y python3-github python3-requests
 
+      - name: Ensure reconciliation token is configured
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROMOTED_LABEL_RECONCILE_TOKEN }}
+        run: |
+          if [ -z "${GITHUB_TOKEN}" ]; then
+            echo "::error::PROMOTED_LABEL_RECONCILE_TOKEN secret is not set - cannot reconcile labels."
+            exit 1
+          fi
+
       - name: Reconcile promoted-to-* labels
         working-directory: .github/scripts
         env:


### PR DESCRIPTION
## Summary

`search_commits.py` only ever labels PRs off a single push event's exact `before..after` commit range. If that push's webhook is ever dropped by GitHub, the promoting commit is never scanned and the PR is left without its `promoted-to-*` label with nothing to retry it.

This is exactly what happened to `scylladb/scylladb#30992`: the commit closing the PR landed on `master`, but no `push` webhook fired for it at all in a ~28.5h window (confirmed against Actions run history - no push-triggered workflow of any kind fired for `master` between the two nearest recorded pushes), so `search_commits.py` never got a chance to see it.

- Extracted the per-commit labeling logic out of `search_commits.py`'s `main()` into a reusable `label_promoted_commits()` function (behavior for the existing push-triggered path is unchanged).
- Added `reconcile_promoted_labels.py`, which re-scans the last `--lookback` commits of each given branch and reuses `label_promoted_commits()`. Safe to re-run over already-labeled commits, since adding a label a PR already has is a no-op.
- Added `reconcile-promoted-labels.yaml`, a scheduled workflow (every 2h, plus `workflow_dispatch`) that runs the reconciliation script, independent of push events.

## Follow-up needed from a repo admin

This workflow needs a `PROMOTED_LABEL_RECONCILE_TOKEN` secret added to this repo (or reuse an existing token with equivalent scope, e.g. whatever backs `AUTO_BACKPORT_TOKEN` in `scylladb/scylladb`) with `issues:write`/`pull-requests:write` on the target repos. I can't add secrets myself.

By default the workflow only reconciles `scylladb/scylladb@master`; use `workflow_dispatch` inputs (or extend the default `branches`) to cover release branches or other repos as needed.

## Test plan

- [x] `pytest .github/tests/` - 462 passed (added 11 new tests in `test_search_commits.py`, covering the search-API path, the `Closes #NNN` fallback that would have caught #30992, cross-branch filtering, and PR dedup across commits)
- [x] Both scripts compile (`py_compile`) and the new workflow YAML parses
- [ ] Admin adds the reconciliation token secret
- [ ] First scheduled/manual run on `scylladb/scylladb` confirmed green

Fixes: https://scylladb.atlassian.net/browse/RELENG-824