### PR TITLE
Inherit backport ticket sprint from the parent issue

### DIFF
--- a/.github/scripts/auto-backport-jira.py
+++ b/.github/scripts/auto-backport-jira.py
@@ -831,55 +831,158 @@ def create_jira_linked_issue(parent_key: str, version: str, original_title: str,
     return new_key
 
 
-def find_active_sprint_id(project_key: str) -> Optional[int]:
+def get_issue_sprint_id(issue: dict) -> Optional[int]:
+    """
+    Read the active sprint id from a Jira issue's Sprint field, if any.
+
+    The field returns every sprint the issue has ever passed through; only the
+    one currently marked 'active' reflects where the issue is right now.
+    """
+    try:
+        sprints = issue.get("fields", {}).get(JIRA_SPRINT_FIELD)
+    except Exception:
+        return None
+    if not sprints:
+        return None
+    for sprint in sprints:
+        if isinstance(sprint, dict) and sprint.get("state") == "active":
+            return sprint.get("id")
+    return None
+
+
+# Distinct from a real "the parent has no active sprint" result, so a transient
+# API failure while reading the parent isn't mistaken for that and doesn't cause
+# Distinct from a real "no active sprint" result, so a failure to look one up
+# (a transient API error, or the request itself failing) isn't mistaken for
+# that and doesn't cause schedule_backport_issue() to unschedule (move to
+# backlog) a backport that's actually fine -- we just couldn't confirm it.
+SPRINT_LOOKUP_FAILED = object()
+
+
+def resolve_parent_sprint_id(parent_key: str):
+    """
+    Find the sprint a backport issue should inherit: the sprint parent_key is
+    currently in. This keeps the backport on the same team's board instead of
+    whichever other team's board happens to be first when searching by project
+    key alone (see RELENG-827).
+
+    Returns a sprint id, None if the parent has no active sprint, or
+    SPRINT_LOOKUP_FAILED if the parent issue itself couldn't be read.
+    """
+    parent_issue = get_jira_issue(parent_key)
+    if parent_issue is None:
+        return SPRINT_LOOKUP_FAILED
+    return get_issue_sprint_id(parent_issue)
+
+
+def find_active_sprint_id(project_key: str):
     """
     Find the id of the sprint currently running for a project, by asking the Agile
     API for the project's boards and taking the first one with an active sprint.
 
     Returns None when the project has no scrum board or is between sprints -- both
-    are normal, and simply mean the issue stays in the backlog.
+    are normal, and simply mean the issue stays in the backlog. Returns
+    SPRINT_LOOKUP_FAILED when the search couldn't be completed reliably: either
+    the board lookup itself failed (a failed request returns None from
+    jira_api_request, distinct from the {} a successful-but-empty response
+    gives), or a per-board sprint request failed and no active sprint was found
+    on any other board -- a per-board failure is usually just a Kanban board
+    (which has no sprints and answers this with an error) and is otherwise
+    harmless to skip, but if it's the reason we come up empty-handed we can't
+    tell that apart from a real failure hiding the active sprint.
     """
     if project_key in _active_sprint_cache:
         return _active_sprint_cache[project_key]
 
     sprint_id = None
+    lookup_failed = False
+    any_board_sprint_failed = False
     try:
         boards = jira_api_request("GET", f"board?projectKeyOrId={project_key}", api_base="agile/1.0")
-        for board in (boards or {}).get("values", []):
-            board_id = board.get("id")
-            if board_id is None:
-                continue
-            # Kanban boards have no sprints and answer this with an error
-            sprints = jira_api_request("GET", f"board/{board_id}/sprint?state=active",
-                                       api_base="agile/1.0")
-            for sprint in (sprints or {}).get("values", []):
-                sprint_id = sprint.get("id")
-                if sprint_id is not None:
-                    logging.info(f"Active sprint for {project_key}: {sprint.get('name')} (id {sprint_id})")
-                    break
-            if sprint_id is not None:
-                break
+        if boards is None:
+            lookup_failed = True
         else:
-            logging.info(f"No active sprint found for project {project_key}")
+            for board in boards.get("values", []):
+                board_id = board.get("id")
+                if board_id is None:
+                    continue
+                sprints = jira_api_request("GET", f"board/{board_id}/sprint?state=active",
+                                           api_base="agile/1.0")
+                if sprints is None:
+                    any_board_sprint_failed = True
+                    continue
+                for sprint in sprints.get("values", []):
+                    sprint_id = sprint.get("id")
+                    if sprint_id is not None:
+                        logging.info(f"Active sprint for {project_key}: {sprint.get('name')} (id {sprint_id})")
+                        break
+                if sprint_id is not None:
+                    break
+            else:
+                logging.info(f"No active sprint found for project {project_key}")
     except Exception as e:
         logging.warning(f"Error looking up the active sprint for {project_key}: {e}")
+        lookup_failed = True
+
+    if sprint_id is None and any_board_sprint_failed:
+        lookup_failed = True
+
+    if lookup_failed:
+        # Don't cache a failure -- a later run should retry instead of being
+        # stuck treating this project as having no active sprint forever.
+        return SPRINT_LOOKUP_FAILED
 
     _active_sprint_cache[project_key] = sprint_id
     return sprint_id
 
 
-def schedule_backport_issue(issue_key: str) -> bool:
+def move_issue_to_backlog(issue_key: str) -> bool:
+    """
+    Move an issue out of whatever sprint it's currently in and into the backlog.
+
+    Omitting the Sprint field from an issue-update PUT leaves an existing sprint
+    untouched rather than clearing it, so removing an issue from a sprint needs
+    this dedicated Agile endpoint instead.
+    """
+    result = jira_api_request("POST", "backlog/issue", {"issues": [issue_key]}, api_base="agile/1.0")
+    return result is not None
+
+
+def schedule_backport_issue(issue_key: str, parent_key: str = None) -> bool:
     """
     Put a backport issue into the current sprint with a zero estimate, so it shows up
     on the board as soon as its backport PR is open instead of sitting in the backlog.
 
+    Inherits the sprint the parent issue is currently in, which is guaranteed to be
+    the right team's sprint. If the parent isn't in an active sprint, the backport
+    is moved to the backlog too, rather than guessing an active sprint by searching
+    the project's boards -- that search can land on an unrelated team's board (see
+    RELENG-827) and schedules work the parent issue itself isn't scheduled for.
+
+    The board search remains as a fallback only when no parent is known at all.
+
     Best-effort: a failure here must never break the backport itself.
     """
-    sprint_id = find_active_sprint_id(extract_project_from_jira_key(issue_key))
+    sprint_id = resolve_parent_sprint_id(parent_key) if parent_key else \
+        find_active_sprint_id(extract_project_from_jira_key(issue_key))
+
+    if sprint_id is SPRINT_LOOKUP_FAILED:
+        # We couldn't confirm the sprint one way or the other -- leave the
+        # backport as-is rather than acting on what may be a transient API
+        # failure (e.g. moving it to the backlog when it may not belong there).
+        logging.warning(f"Could not determine the sprint to schedule {issue_key} into; leaving it as-is")
+        return False
 
     fields = {JIRA_STORY_POINTS_FIELD: BACKPORT_STORY_POINTS}
     if sprint_id is not None:
         fields[JIRA_SPRINT_FIELD] = sprint_id
+    else:
+        # A prior run may have already put this issue in a sprint (e.g. while the
+        # parent still had one) -- make sure it doesn't linger there. If we can't
+        # confirm that, don't report success: the issue may still be misscheduled.
+        if not move_issue_to_backlog(issue_key):
+            logging.warning(f"Could not move {issue_key} to the backlog")
+            return False
 
     result = jira_api_request("PUT", f"issue/{issue_key}", {"fields": fields})
     if result is None and sprint_id is not None:
@@ -905,7 +1008,7 @@ def schedule_backport_issues(jira_mapping: Dict[str, str]):
         return
     for parent_key, backport_key in (jira_mapping or {}).items():
         if backport_key and backport_key != parent_key:
-            schedule_backport_issue(backport_key)
+            schedule_backport_issue(backport_key, parent_key)
 
 
 def add_jira_comment(issue_key: str, comment: str) -> bool:

--- a/.github/tests/test_jira_functions.py
+++ b/.github/tests/test_jira_functions.py
@@ -759,9 +759,139 @@ class TestFindActiveSprintId:
             assert bp_module.find_active_sprint_id("RELENG") == 2112
             assert mock_api.call_count == 2
 
+    def test_sentinel_when_board_lookup_fails(self, bp_module):
+        """A failed board request must be distinguishable from a project that
+        genuinely has no boards, so it isn't mistaken for 'no active sprint'
+        (see the CodeRabbit finding on RELENG-827)."""
+        with patch.object(bp_module, "jira_api_request", return_value=None):
+            assert bp_module.find_active_sprint_id("RELENG") is bp_module.SPRINT_LOOKUP_FAILED
+
+    def test_failure_is_not_cached(self, bp_module):
+        responses = [None, {"values": [{"id": 608}]}, {"values": [{"id": 2112, "state": "active"}]}]
+        with patch.object(bp_module, "jira_api_request", side_effect=responses) as mock_api:
+            assert bp_module.find_active_sprint_id("RELENG") is bp_module.SPRINT_LOOKUP_FAILED
+            assert bp_module.find_active_sprint_id("RELENG") == 2112
+            assert mock_api.call_count == 3
+
+    def test_sentinel_when_a_board_sprint_request_fails_and_none_found_elsewhere(self, bp_module):
+        """A per-board sprint request answering with an error usually just means
+        that board is Kanban (harmless to skip, see test_skips_board_without_
+        active_sprint), but if we end up with no active sprint anywhere, that
+        failure might be hiding a real one -- report it as unreliable rather
+        than as a confirmed 'no active sprint' (CodeRabbit finding on
+        RELENG-827)."""
+        responses = [{"values": [{"id": 1}, {"id": 2}]}, None, {"values": []}]
+        with patch.object(bp_module, "jira_api_request", side_effect=responses):
+            assert bp_module.find_active_sprint_id("RELENG") is bp_module.SPRINT_LOOKUP_FAILED
+
+
+class TestGetIssueSprintId:
+    def test_returns_active_sprint(self, bp_module):
+        issue = {"fields": {bp_module.JIRA_SPRINT_FIELD: [
+            {"id": 2100, "state": "closed"},
+            {"id": 2112, "state": "active"},
+        ]}}
+        assert bp_module.get_issue_sprint_id(issue) == 2112
+
+    def test_none_when_no_active_sprint(self, bp_module):
+        issue = {"fields": {bp_module.JIRA_SPRINT_FIELD: [{"id": 2100, "state": "closed"}]}}
+        assert bp_module.get_issue_sprint_id(issue) is None
+
+    def test_none_when_field_missing(self, bp_module):
+        assert bp_module.get_issue_sprint_id({"fields": {}}) is None
+
+
+class TestResolveParentSprintId:
+    def test_returns_parents_active_sprint(self, bp_module):
+        parent_issue = {"fields": {bp_module.JIRA_SPRINT_FIELD: [{"id": 2112, "state": "active"}]}}
+        with patch.object(bp_module, "get_jira_issue", return_value=parent_issue):
+            assert bp_module.resolve_parent_sprint_id("RELENG-785") == 2112
+
+    def test_none_when_parent_has_no_active_sprint(self, bp_module):
+        parent_issue = {"fields": {}}
+        with patch.object(bp_module, "get_jira_issue", return_value=parent_issue):
+            assert bp_module.resolve_parent_sprint_id("RELENG-785") is None
+
+    def test_sentinel_when_parent_lookup_fails(self, bp_module):
+        """A failed lookup must be distinguishable from a real 'no sprint' result,
+        so a transient API error doesn't get treated as one (see the CodeRabbit
+        finding on RELENG-827)."""
+        with patch.object(bp_module, "get_jira_issue", return_value=None):
+            assert bp_module.resolve_parent_sprint_id("RELENG-785") is bp_module.SPRINT_LOOKUP_FAILED
+
+
+class TestMoveIssueToBacklog:
+    def test_success(self, bp_module):
+        with patch.object(bp_module, "jira_api_request", return_value={}) as mock_api:
+            assert bp_module.move_issue_to_backlog("RELENG-800") is True
+            method, endpoint, data = mock_api.call_args[0]
+            assert (method, endpoint) == ("POST", "backlog/issue")
+            assert data == {"issues": ["RELENG-800"]}
+            assert mock_api.call_args.kwargs["api_base"] == "agile/1.0"
+
+    def test_failure(self, bp_module):
+        with patch.object(bp_module, "jira_api_request", return_value=None):
+            assert bp_module.move_issue_to_backlog("RELENG-800") is False
+
 
 class TestScheduleBackportIssue:
-    def test_sets_sprint_and_zero_points(self, bp_module):
+    def test_inherits_parents_sprint_over_board_search(self, bp_module):
+        """The parent's own sprint must win over the ambiguous project-wide board
+        search (see RELENG-827 -- that search can return another team's sprint)."""
+        with patch.object(bp_module, "resolve_parent_sprint_id", return_value=2112), \
+             patch.object(bp_module, "find_active_sprint_id") as mock_find, \
+             patch.object(bp_module, "jira_api_request", return_value={}) as mock_api:
+            assert bp_module.schedule_backport_issue("RELENG-800", "RELENG-785") is True
+            mock_find.assert_not_called()
+            method, endpoint, data = mock_api.call_args[0]
+            assert (method, endpoint) == ("PUT", "issue/RELENG-800")
+            assert data["fields"][bp_module.JIRA_SPRINT_FIELD] == 2112
+            assert data["fields"][bp_module.JIRA_STORY_POINTS_FIELD] == 0
+
+    def test_leaves_unscheduled_when_parent_has_no_active_sprint(self, bp_module):
+        """If the parent isn't in a sprint, the backport shouldn't be either -- not
+        even by falling back to an unrelated board's active sprint (RELENG-827)."""
+        with patch.object(bp_module, "resolve_parent_sprint_id", return_value=None), \
+             patch.object(bp_module, "find_active_sprint_id") as mock_find, \
+             patch.object(bp_module, "move_issue_to_backlog") as mock_backlog, \
+             patch.object(bp_module, "jira_api_request", return_value={}) as mock_api:
+            assert bp_module.schedule_backport_issue("RELENG-800", "RELENG-785") is True
+            mock_find.assert_not_called()
+            mock_backlog.assert_called_once_with("RELENG-800")
+            assert bp_module.JIRA_SPRINT_FIELD not in mock_api.call_args[0][2]["fields"]
+
+    def test_fails_without_put_when_backlog_move_fails(self, bp_module):
+        """A failed backlog move must not be reported as success -- the issue may
+        still be sitting in a stale sprint from an earlier run."""
+        with patch.object(bp_module, "resolve_parent_sprint_id", return_value=None), \
+             patch.object(bp_module, "move_issue_to_backlog", return_value=False), \
+             patch.object(bp_module, "jira_api_request") as mock_api:
+            assert bp_module.schedule_backport_issue("RELENG-800", "RELENG-785") is False
+            mock_api.assert_not_called()
+
+    def test_fails_without_side_effects_when_parent_lookup_fails(self, bp_module):
+        """A transient failure to read the parent must not be treated as 'parent
+        has no active sprint' -- that would wrongly move the backport to the
+        backlog on what may just be a flaky API call (RELENG-827)."""
+        with patch.object(bp_module, "resolve_parent_sprint_id",
+                           return_value=bp_module.SPRINT_LOOKUP_FAILED), \
+             patch.object(bp_module, "move_issue_to_backlog") as mock_backlog, \
+             patch.object(bp_module, "jira_api_request") as mock_api:
+            assert bp_module.schedule_backport_issue("RELENG-800", "RELENG-785") is False
+            mock_backlog.assert_not_called()
+            mock_api.assert_not_called()
+
+    def test_fails_without_side_effects_when_board_search_fails(self, bp_module):
+        """Same as the parent-lookup failure case, but for the no-parent board
+        search fallback (see the CodeRabbit finding on RELENG-827)."""
+        with patch.object(bp_module, "find_active_sprint_id", return_value=bp_module.SPRINT_LOOKUP_FAILED), \
+             patch.object(bp_module, "move_issue_to_backlog") as mock_backlog, \
+             patch.object(bp_module, "jira_api_request") as mock_api:
+            assert bp_module.schedule_backport_issue("RELENG-800") is False
+            mock_backlog.assert_not_called()
+            mock_api.assert_not_called()
+
+    def test_uses_board_search_when_no_parent_given(self, bp_module):
         with patch.object(bp_module, "find_active_sprint_id", return_value=2112), \
              patch.object(bp_module, "jira_api_request", return_value={}) as mock_api:
             assert bp_module.schedule_backport_issue("RELENG-800") is True
@@ -772,8 +902,10 @@ class TestScheduleBackportIssue:
 
     def test_sets_points_even_without_an_active_sprint(self, bp_module):
         with patch.object(bp_module, "find_active_sprint_id", return_value=None), \
+             patch.object(bp_module, "move_issue_to_backlog") as mock_backlog, \
              patch.object(bp_module, "jira_api_request", return_value={}) as mock_api:
             assert bp_module.schedule_backport_issue("RELENG-800") is True
+            mock_backlog.assert_called_once_with("RELENG-800")
             data = mock_api.call_args[0][2]
             assert data["fields"][bp_module.JIRA_STORY_POINTS_FIELD] == 0
             assert bp_module.JIRA_SPRINT_FIELD not in data["fields"]
@@ -791,11 +923,13 @@ class TestScheduleBackportIssue:
 
 
 class TestScheduleBackportIssues:
-    def test_schedules_each_backport_issue(self, bp_module):
+    def test_schedules_each_backport_issue_with_its_parent(self, bp_module):
         mapping = {"RELENG-785": "RELENG-800", "SCYLLADB-1": "SCYLLADB-2"}
         with patch.object(bp_module, "schedule_backport_issue") as mock_sched:
             bp_module.schedule_backport_issues(mapping)
-            assert {c[0][0] for c in mock_sched.call_args_list} == {"RELENG-800", "SCYLLADB-2"}
+            assert {c[0] for c in mock_sched.call_args_list} == {
+                ("RELENG-800", "RELENG-785"), ("SCYLLADB-2", "SCYLLADB-1"),
+            }
 
     def test_skips_parent_key_fallback(self, bp_module):
         """When no backport issue was resolved the mapping points at the parent -- the


### PR DESCRIPTION
Inherit backport ticket sprint from the parent issue

find_active_sprint_id() picked the active sprint from whichever board
came back first for the project, which can belong to an unrelated
team when multiple boards track the same project's issues. Backport
tickets now inherit the sprint the parent issue is currently in
(mirroring how Team is already inherited); if the parent isn't in an
active sprint, the backport is moved to the backlog instead of guessing.

Omitting the Sprint field from an issue-update PUT leaves any existing
sprint untouched rather than clearing it, so a backport issue scheduled
into a sprint on an earlier run (while its parent still had one) is
moved to the backlog explicitly via the Agile backlog endpoint once the
parent drops out of its sprint. A failed backlog move is reported as a
failure rather than silently proceeding to report success.

A failure to look up the relevant sprint is kept distinct from "no
active sprint", via a shared SPRINT_LOOKUP_FAILED sentinel, so a
transient API error doesn't get mistaken for that and cause the
backport to be unscheduled. This covers reading the parent issue,
searching a project's boards in the no-parent fallback, and a per-board
sprint request failing with no active sprint found elsewhere (a
per-board failure alone is usually just a harmless Kanban board, which
has no sprints and answers this with an error, but if it's the reason
the search comes up empty it might be hiding a real active sprint).

Fixes: RELENG-827